### PR TITLE
Skip recording rules when adding custom annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 - Detection of component presence ([#13])
+- Skip recording rules when adding custom annotations ([#19])
 
 [Unreleased]: https://github.com/appuio/component-openshift4-monitoring/compare/d503a46ca74c912d7599da47a6bb2910dc484d23...HEAD
 [#1]: https://github.com/appuio/component-openshift4-monitoring/pull/1
@@ -42,3 +43,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#14]: https://github.com/appuio/component-openshift4-monitoring/pull/14
 [#17]: https://github.com/appuio/component-openshift4-monitoring/pull/17
 [#18]: https://github.com/appuio/component-openshift4-monitoring/pull/18
+[#19]: https://github.com/appuio/component-openshift4-monitoring/pull/19

--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -78,16 +78,22 @@ local annotateRules = {
         group {
           rules: std.map(
             function(rule)
-              local annotations =
-                defaultAnnotations +
-                if std.objectHas(rule, 'alert') && std.objectHas(customAnnotations, rule.alert) then
-                  customAnnotations[rule.alert]
-                else
-                  {};
+              // Only add custom annotations to alert rules, since recording
+              // rules cannot have annotations.
+              // We identify alert rules by the presence of the `alert` field.
+              if std.objectHas(rule, 'alert') then
+                local annotations =
+                  defaultAnnotations +
+                  if std.objectHas(customAnnotations, rule.alert) then
+                    customAnnotations[rule.alert]
+                  else
+                    {};
 
-              rule {
-                annotations+: annotations,
-              },
+                rule {
+                  annotations+: annotations,
+                }
+              else
+                rule,
             group.rules
           ),
         },


### PR DESCRIPTION
Recording rules cannot have field annotations, so we exclude them when adding our custom annotations. We identify recording rules by the absence of field alert in the rule object.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
