### PR TITLE
Remove SHA from image tag

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -68,4 +68,4 @@ parameters:
     images:
       oc:
         image: quay.io/appuio/oc
-        tag: v4.6@sha256:d7a50d8812bc13e2a1cef119d268ebb051e9ffb53960942180a36982ec59f647
+        tag: v4.6


### PR DESCRIPTION
quay.io purges unreferenced image layers. Having a fixed sha here will
brake things sooner or later.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
