### PR TITLE
Change component to not "take over" the openshift-monitoring namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.0]
+
+### Fixed
+
+- Component doesn't "take over" the `openshift-monitoring` namespace object ([#26])
+
 ## [v0.1.0]
 
 ### Added
@@ -32,8 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detection of component presence ([#13])
 - Skip recording rules when adding custom annotations ([#19])
 
-[Unreleased]: https://github.com/appuio/component-openshift4-monitoring/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/appuio/component-openshift4-monitoring/compare/v1.0.0...HEAD
 [v0.1.0]: https://github.com/appuio/component-openshift4-monitoring/releases/tag/v0.1.0
+[v1.0.0]: https://github.com/appuio/component-openshift4-monitoring/releases/tag/v1.0.0
 
 [#1]: https://github.com/appuio/component-openshift4-monitoring/pull/1
 [#2]: https://github.com/appuio/component-openshift4-monitoring/pull/2
@@ -48,3 +55,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#17]: https://github.com/appuio/component-openshift4-monitoring/pull/17
 [#18]: https://github.com/appuio/component-openshift4-monitoring/pull/18
 [#19]: https://github.com/appuio/component-openshift4-monitoring/pull/19
+[#26]: https://github.com/appuio/component-openshift4-monitoring/pull/26

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -1,26 +1,39 @@
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
+local rl = import 'lib/resource-locker.libjsonnet';
+
 local inv = kap.inventory();
 local params = inv.parameters.openshift4_monitoring;
 
 local rules = import 'rules.jsonnet';
 
+local ns =
+  if params.namespace != 'openshift-monitoring' then
+    error 'Component openshift4-monitoring does not support values for parameter `namespace` other than "openshift-monitoring".'
+  else
+    params.namespace;
+
+local ns_patch =
+  rl.Patch(
+    kube.Namespace(ns),
+    {
+      metadata: {
+        labels: {
+          'network.openshift.io/policy-group': 'monitoring',
+        } + if std.member(inv.applications, 'networkpolicy') then {
+          [inv.parameters.networkpolicy.labels.noDefaults]: 'true',
+          [inv.parameters.networkpolicy.labels.purgeDefaults]: 'true',
+        },
+      },
+    }
+  );
+
 {
-  '00_namespace': kube.Namespace(params.namespace) {
-    metadata+: {
-      annotations:: {},
-      labels+: {
-        'network.openshift.io/policy-group': 'monitoring',
-      } + if std.member(inv.applications, 'networkpolicy') then {
-        [inv.parameters.networkpolicy.labels.noDefaults]: 'true',
-        [inv.parameters.networkpolicy.labels.purgeDefaults]: 'true',
-      } else {},
-    },
-  },
+  '00_namespace_labels': ns_patch,
   [if std.length(params.configs) > 0 then '10_configmap']:
     kube.ConfigMap('cluster-monitoring-config') {
       metadata+: {
-        namespace: params.namespace,
+        namespace: ns,
       },
       data: {
         'config.yaml': std.manifestYamlDoc(
@@ -33,7 +46,7 @@ local rules = import 'rules.jsonnet';
     },
   '10_alertmanager_config': kube.Secret('alertmanager-main') {
     metadata+: {
-      namespace: params.namespace,
+      namespace: ns,
     },
     stringData: {
       'alertmanager.yaml': std.manifestYamlDoc(params.alertManagerConfig),

--- a/docs/modules/ROOT/pages/how-tos/migrate/v0.1-v1.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/migrate/v0.1-v1.x.adoc
@@ -1,0 +1,106 @@
+= Migrate from component version v0.1.0 to v1.x
+
+Due to the nature of the fix for #24, migrating to the fixed version of the component requires a couple manual steps.
+
+This document guides you through the migration.
+
+NOTE: While we give `oc` commands to manage the ArgoCD apps, you can also perform those steps through the ArgoCD UI, if you prefer.
+
+== Prerequisites
+
+* `oc` CLI available and logged into the cluster as a user which can impersonate `cluster-admin`
+* `argocd` CLI available, see https://argo-cd.readthedocs.io/en/stable/cli_installation/[ArgoCD CLI installation documentation]
+
+== Procedure
+
+. Setup port-forward to ArgoCD and login to ArgoCD with the CLI
++
+[source,shell]
+----
+oc --as=cluster-admin -n syn port-forward svc/argocd-server 8080:80 & sleep 1
+argocd login --plaintext --username=admin --password=$(oc --as=cluster-admin -n syn get secret steward -ojsonpath='{.data.token}' |base64 -d) localhost:8080
+----
+
+. Disable auto-sync for the ArgoCD apps `root` and `openshift4-monitoring`
++
+With `argocd`:
++
+[source,shell]
+----
+argocd app set --sync-option=none root
+argocd app set --sync-option=none openshift4-monitoring
+----
++
+With `oc`:
++
+[source,shell]
+----
+oc --as=cluster-admin -n syn patch apps root --type=json \
+  -p '[{"op":"replace", "path":"/spec/syncPolicy", "value": {}}]'
+oc --as=cluster-admin -n syn patch apps openshift4-monitoring --type=json \
+  -p '[{"op":"replace", "path":"/spec/syncPolicy", "value": {}}]'
+----
+
+. Remove ArgoCD managed-by label from the `openshift-monitoring` namespace object
++
+[source,shell]
+----
+oc --as=cluster-admin label ns openshift-monitoring argocd.argoproj.io/instance-
+----
+
+. Update cluster to use openshift4-monitoring v1.0.0. Add the following configuration in the cluster config:
++
+.inventory/classes/<tenant-id>/<cluster-id>.yml
+[source,yaml]
+----
+parameters:
+  components:
+    openshift4_monitoring:
+      version: v1.0.0
+----
+
+. Compile and push catalog
++
+[source,shell]
+----
+commodore catalog compile --push -i <cluster-id>
+----
+
+. Trigger a hard refresh of `openshift4-monitoring` app
++
+[source,shell]
+----
+argocd app get --hard-refresh openshift4-monitoring
+----
++
+NOTE: You can trigger a hard refresh via the ArgoCD UI instead of using the ArgoCD CLI command.
+
+. Sync `root` app
++
+With `argocd`:
++
+[source,shell]
+----
+argocd app sync root
+----
++
+With `oc`:
++
+[source,shell]
+----
+oc --as=cluster-admin -n syn patch apps root --type=json \
+  -p '[{
+    "op":"replace",
+    "path":"/spec/syncPolicy",
+    "value": {"automated": {"prune": true, "selfHeal": true}}
+  }]'
+----
++
+NOTE: With `oc` we don't directly trigger a sync, but instead re-enable auto-sync in the app object.
+
+. Terminate port-forward to ArgoCD
++
+[source,shell]
+----
+kill %1
+----

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -1,3 +1,7 @@
 * xref:index.adoc[Home]
+.Reference
 * xref:references/parameters.adoc[Parameters]
+
+.How-Tos
 * xref:how-tos/opsgenie.adoc[OpsGenie integration]
+* xref:how-tos/migrate/v0.1-v1.x.adoc[Migration from component version v0.1.0 to v1.x]


### PR DESCRIPTION
This PR changes the component to not make the `openshift-monitoring` namespace object itself managed by Syn ArgoCD.

This change ensures that deactivating the component on a cluster will not delete the whole OpenShift cluster-monitoring component.

Instead, the component now uses the resource-locker component to add the desired labels to the existing namespace object.

Additionally, since changing the namespace value for the component doesn't make sense at the moment, an error is printed if a value other than `openshift-monitoring` is detected for `parameters.openshift4_monitoring.namepace`.

Fixes #24

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update documentation.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
