### PR TITLE
User defined monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.1.0]
+
+### Added
+
+- Add parameter `enableUserWorkload` ([#28])
+
 ## [v1.0.0]
 
 ### Fixed
@@ -38,9 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detection of component presence ([#13])
 - Skip recording rules when adding custom annotations ([#19])
 
-[Unreleased]: https://github.com/appuio/component-openshift4-monitoring/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/appuio/component-openshift4-monitoring/compare/v1.1.0...HEAD
 [v0.1.0]: https://github.com/appuio/component-openshift4-monitoring/releases/tag/v0.1.0
 [v1.0.0]: https://github.com/appuio/component-openshift4-monitoring/releases/tag/v1.0.0
+[v1.1.0]: https://github.com/appuio/component-openshift4-monitoring/releases/tag/v1.1.0
 
 [#1]: https://github.com/appuio/component-openshift4-monitoring/pull/1
 [#2]: https://github.com/appuio/component-openshift4-monitoring/pull/2
@@ -56,3 +63,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#18]: https://github.com/appuio/component-openshift4-monitoring/pull/18
 [#19]: https://github.com/appuio/component-openshift4-monitoring/pull/19
 [#26]: https://github.com/appuio/component-openshift4-monitoring/pull/26
+[#28]: https://github.com/appuio/component-openshift4-monitoring/pull/28

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,6 +4,7 @@ parameters:
     defaultConfig:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
+    enableUserWorkload: false
     configs:
       prometheusK8s:
         externalLabels:

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -38,7 +38,7 @@ local ns_patch =
       data: {
         'config.yaml': std.manifestYamlDoc(
           {
-            'enableUserWorkload': params.enableUserWorkload
+            enableUserWorkload: params.enableUserWorkload,
           } + std.mapWithKey(
             function(field, value) value + params.defaultConfig,
             params.configs

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -37,7 +37,9 @@ local ns_patch =
       },
       data: {
         'config.yaml': std.manifestYamlDoc(
-          std.mapWithKey(
+          {
+            'enableUserWorkload': params.enableUserWorkload
+          } + std.mapWithKey(
             function(field, value) value + params.defaultConfig,
             params.configs
           )

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -16,6 +16,14 @@ nodeSelector:
 
 A dictionary holding the default configuration which should be applied to all components.
 
+== `enableUserWorkload`
+
+[horizontal]
+type:: boolean
+default:: false
+
+A parameter to enable https://docs.openshift.com/container-platform/4.7/monitoring/enabling-monitoring-for-user-defined-projects.html[monitoring for user-defined projects].
+
 == `configs`
 
 [horizontal]


### PR DESCRIPTION
This PR adds the parameter `enableUserWorkload` to allow [monitoring for user-defined projects](https://docs.openshift.com/container-platform/4.7/monitoring/enabling-monitoring-for-user-defined-projects.html).

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
