### PR TITLE
Sort Rules by name

### DIFF
--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -134,7 +134,7 @@ local rules =
       {
         local group = rules[alertGroupName],
         name: 'syn-' + group.name,
-        rules: [
+        rules: std.sort([
           rule {
             alert: if rule.alert != 'Watchdog' then
               'SYN_' + rule.alert
@@ -145,7 +145,7 @@ local rules =
             },
           }
           for rule in group.rules
-        ],
+        ], function(r) r.alert),
       }
       for alertGroupName in std.sort(std.objectFields(rules))
     ],


### PR DESCRIPTION
This prevents catalog commits where the only change is reordered alert rules.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] ~Update the documentation.~
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] ~Link this PR to related issues.~
