### PR TITLE
Add support for patching upstream rules

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -59,6 +59,10 @@ parameters:
     alerts:
       ignoreNames: []
       customAnnotations: {}
+      patchRules:
+        release-4.7:
+          SystemMemoryExceedsReservation:
+            for: 15m
 
     silence:
       schedule: '0 */4 * * *'

--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -104,12 +104,12 @@ local annotateRules = {
   },
 };
 
-local rulePatches = {
-  // upstream SystemMemoryExceedsReservation rule doesn't have `for` field
-  SystemMemoryExceedsReservation: {
-    'for': '15m',
-  },
-};
+local rulePatches =
+  com.getValueOrDefault(
+    params.alerts.patchRules,
+    params.manifests_version,
+    {}
+  );
 
 local patchRules = {
   spec+: {
@@ -118,8 +118,11 @@ local patchRules = {
         group {
           rules: std.map(
             function(rule)
-              if std.objectHas(rulePatches, rule.alert) then
-                rule + rulePatches[rule.alert]
+              if (
+                std.objectHas(rule, 'alert') &&
+                std.objectHas(rulePatches, rule.alert)
+              ) then
+                rule + com.makeMergeable(rulePatches[rule.alert])
               else
                 rule,
             group.rules

--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -104,6 +104,32 @@ local annotateRules = {
   },
 };
 
+local rulePatches = {
+  // upstream SystemMemoryExceedsReservation rule doesn't have `for` field
+  SystemMemoryExceedsReservation: {
+    'for': '15m',
+  },
+};
+
+local patchRules = {
+  spec+: {
+    groups: std.map(
+      function(group)
+        group {
+          rules: std.map(
+            function(rule)
+              if std.objectHas(rulePatches, rule.alert) then
+                rule + rulePatches[rule.alert]
+              else
+                rule,
+            group.rules
+          ),
+        },
+      super.groups
+    ),
+  },
+};
+
 local rules =
   std.foldl(
     function(x, y)
@@ -115,6 +141,7 @@ local rules =
       + additionalRules
       + annotateRules
       + filterRules
+      + patchRules
     ).spec.groups,
     {},
   );

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -153,6 +153,27 @@ customAnnotations:
     runbook_url: https://www.google.com/?q=Watchdog
 ----
 
+=== `patchRules`
+type:: dict
+keys:: potential values of parameter `manifests_versions`
+default:: See https://github.com/appuio/component-openshift4-monitoring/blob/master/class/defaults.yml[`class/defaults.yml` on GitHub]
+
+The parameter `patchRules` allows users to customize upstream alerts.
+The component expects that top-level keys in the parameter correspond to values of parameter `manifests_versions`.
+This enables users to selectively patch upstream alerts for a particular OpenShift 4 version.
+
+For each version, the component expects alert names as keys and any alert configuration as values.
+See the Prometheus https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/[alerting rules documentation] for extended documentation on configuring alerting rules.
+
+Example:
+
+[source,yaml]
+----
+patchRules:
+  release-4.7:
+    SystemMemoryExceedsReservation:
+      for: 30m
+----
 
 == `silence`
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -222,7 +222,7 @@ default:: 3
 
 Number of failed jobs to keep.
 
-==== `successfull`
+==== `successful`
 
 [horizontal]
 type:: number


### PR DESCRIPTION
This allows us to adjust upstream rules which we want to keep but which need some tuning.

This feature can be used by adding the desired change for a rule in local variable `rulePatches` with the upstream rule name as the key.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
