### PR TITLE
Drop inclusion of removed alert rules

### DIFF
--- a/class/openshift4-monitoring.yml
+++ b/class/openshift4-monitoring.yml
@@ -41,9 +41,6 @@ parameters:
         source: https://raw.githubusercontent.com/openshift/machine-api-operator/${openshift4_monitoring:manifests_version}/install/0000_90_machine-api-operator_04_alertrules.yaml
         output_path: dependencies/openshift4-monitoring/manifests/${openshift4_monitoring:manifests_version}/machine-api-operator.yaml
       - type: https
-        source: https://raw.githubusercontent.com/openshift/cluster-autoscaler-operator/${openshift4_monitoring:manifests_version}/install/09_alertrules.yaml
-        output_path: dependencies/openshift4-monitoring/manifests/${openshift4_monitoring:manifests_version}/cluster-autoscaler-operator.yaml
-      - type: https
         source: https://raw.githubusercontent.com/openshift/machine-config-operator/${openshift4_monitoring:manifests_version}/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
         output_path: dependencies/openshift4-monitoring/manifests/${openshift4_monitoring:manifests_version}/machine-config-operator.yaml
       - type: https


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

The cluster autoscaler operator project dropped the rules to check if the operator is down.
See https://github.com/openshift/cluster-autoscaler-operator/commit/7bbbe7233421b7e13f7dd82bc2553d64b3d7641c.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
