### PR TITLE
Add the capability to exclude upstream rules

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,6 +7,11 @@ parameters:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
     enableUserWorkload: false
+    upstreamRules:
+      networkPlugin: openshift-sdn
+      elasticsearchOperator: true
+      clusterSamplesOperator: true
+      openshiftLogging: true
     configs:
       prometheusK8s:
         externalLabels:

--- a/class/openshift4-monitoring.yml
+++ b/class/openshift4-monitoring.yml
@@ -47,8 +47,11 @@ parameters:
         source: https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/${openshift4_monitoring:manifests_version}/manifests/0000_90_olm_01-prometheus-rule.yaml
         output_path: dependencies/openshift4-monitoring/manifests/${openshift4_monitoring:manifests_version}/operator-lifecycle-manager.yaml
       - type: https
-        source: https://raw.githubusercontent.com/openshift/cluster-network-operator/${openshift4_monitoring:manifests_version}/bindata/network/openshift-sdn/alert-rules.yaml
-        output_path: dependencies/openshift4-monitoring/manifests/${openshift4_monitoring:manifests_version}/openshift-sdn.yaml
+        source: https://raw.githubusercontent.com/openshift/cluster-network-operator/${openshift4_monitoring:manifests_version}/bindata/network/${openshift4_monitoring:upstreamRules:networkPlugin}/alert-rules.yaml
+        output_path: dependencies/openshift4-monitoring/manifests/${openshift4_monitoring:manifests_version}/${openshift4_monitoring:upstreamRules:networkPlugin}.yaml
+      - type: https
+        source: https://raw.githubusercontent.com/openshift/cluster-network-operator/${openshift4_monitoring:manifests_version}/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
+        output_path: dependencies/openshift4-monitoring/manifests/${openshift4_monitoring:manifests_version}/ovn-kubernetes-control-plane.yaml
     compile:
       - input_paths:
           - openshift4-monitoring/component/app.jsonnet

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -27,6 +27,43 @@ nodeSelector:
 
 A dictionary holding the default configuration which should be applied to all components.
 
+
+== `upstreamRules.networkPlugin`
+
+[horizontal]
+type:: boolean
+default:: `openshift-sdn`
+
+Choose either `openshift-sdn` or `ovn-kubernetes` depending on the installed network plugin.
+
+
+== `upstreamRules.elasticsearchOperator`
+
+[horizontal]
+type:: boolean
+default:: `true`
+
+Whether the Elasticsearch Operator prometheus rules should be included or not.
+
+
+== `upstreamRules.clusterSamplesOperator`
+
+[horizontal]
+type:: boolean
+default:: `true`
+
+Whether the Cluster Samples Operator prometheus rules should be included or not.
+
+
+== `upstreamRules.openshiftLogging`
+
+[horizontal]
+type:: boolean
+default:: `true`
+
+Whether the OpenShift Logging Operator prometheus rules should be included or not.
+
+
 == `enableUserWorkload`
 
 [horizontal]


### PR DESCRIPTION
This code add the capablity to switch the rules between the
network plugins openshift-sdn and ovn-kubernetes.
Further it also add the exclude capability for not always required
rules of the Cluster Sample, Logging and ElasticSearch operators.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
