### PR TITLE
Remove cluster logging prometheus rules

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -11,7 +11,6 @@ parameters:
       networkPlugin: openshift-sdn
       elasticsearchOperator: true
       clusterSamplesOperator: true
-      openshiftLogging: true
     configs:
       prometheusK8s:
         externalLabels:

--- a/class/openshift4-monitoring.yml
+++ b/class/openshift4-monitoring.yml
@@ -35,9 +35,6 @@ parameters:
         source: https://raw.githubusercontent.com/openshift/elasticsearch-operator/${openshift4_monitoring:manifests_version}/hack/prometheus-rules.yaml
         output_path: dependencies/openshift4-monitoring/manifests/${openshift4_monitoring:manifests_version}/elasticsearch-operator.yaml
       - type: https
-        source: https://raw.githubusercontent.com/openshift/cluster-logging-operator/${openshift4_monitoring:manifests_version}/files/fluentd/fluentd_prometheus_alerts.yaml
-        output_path: dependencies/openshift4-monitoring/manifests/${openshift4_monitoring:manifests_version}/cluster-logging-operator-fluentd.yaml
-      - type: https
         source: https://raw.githubusercontent.com/openshift/machine-api-operator/${openshift4_monitoring:manifests_version}/install/0000_90_machine-api-operator_04_alertrules.yaml
         output_path: dependencies/openshift4-monitoring/manifests/${openshift4_monitoring:manifests_version}/machine-api-operator.yaml
       - type: https

--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -18,10 +18,6 @@ local upstreamManifestsFileExclude = function(file) (
     file == 'elasticsearch-operator.yaml'
   )
   || (
-    params.upstreamRules.openshiftLogging == false &&
-    file == 'cluster-logging-operator-fluentd.yaml'
-  )
-  || (
     params.upstreamRules.clusterSamplesOperator == false &&
     file == 'cluster-samples-operator.yaml'
   )

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -55,15 +55,6 @@ default:: `true`
 Whether the Cluster Samples Operator prometheus rules should be included or not.
 
 
-== `upstreamRules.openshiftLogging`
-
-[horizontal]
-type:: boolean
-default:: `true`
-
-Whether the OpenShift Logging Operator prometheus rules should be included or not.
-
-
 == `enableUserWorkload`
 
 [horizontal]


### PR DESCRIPTION
Prometheus rules for cluster logging are added to the openshift4-logging component.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
