### PR TITLE
Fix compilation whe networkpolicy component is disabled

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -23,7 +23,7 @@ local ns_patch =
         } + if std.member(inv.applications, 'networkpolicy') then {
           [inv.parameters.networkpolicy.labels.noDefaults]: 'true',
           [inv.parameters.networkpolicy.labels.purgeDefaults]: 'true',
-        },
+        } else {},
       },
     }
   );


### PR DESCRIPTION
The "if" statement will evaluate to `null` in those cases, and an object and null cannot be added apparently.

Original error message:

```
Jsonnet error: failed to compile /builds/aspectra/syn-tenant-repo/vendor/openshift4-monitoring/component/main.jsonnet:
 RUNTIME ERROR: binary operator + requires matching types, got object and null.
	/builds/aspectra/syn-tenant-repo/vendor/openshift4-monitoring/component/main.jsonnet:(21:17)-(26:10)	object <v>
	std.jsonnet:1032:34-38	thunk <value>
	std.jsonnet:1012:28-33	thunk <v>
	std.jsonnet:32:25	
	std.jsonnet:32:16-27	thunk <a>
	std.jsonnet:32:16-38	function <anonymous>
	std.jsonnet:32:16-38	function <anonymous>
	std.jsonnet:1012:16-34	function <params>
	std.jsonnet:1032:27-39	thunk <param>
	std.jsonnet:1030:45-50	thunk <array_element>
	...
	std.jsonnet:1030:59-98	thunk <array_element>
	std.jsonnet:1034:11-42	function <aux>
	std.jsonnet:1035:5-23	function <anonymous>
	/builds/aspectra/syn-tenant-repo/vendor/lib/resource-locker.libjsonnet:60:24-58	object <anonymous>
	/builds/aspectra/syn-tenant-repo/vendor/lib/resource-locker.libjsonnet:(58:18)-(62:8)	thunk <array_element>
	/builds/aspectra/syn-tenant-repo/vendor/lib/resource-locker.libjsonnet:(58:16)-(62:10)	object <anonymous>
	/builds/aspectra/syn-tenant-repo/vendor/lib/resource-locker.libjsonnet:(56:28)-(64:4)	object <anonymous>
	/builds/aspectra/syn-tenant-repo/vendor/lib/resource-locker.libjsonnet:(184:17)-(188:37)	thunk <array_element>
	/builds/aspectra/syn-tenant-repo/vendor/openshift4-monitoring/component/main.jsonnet:32:26-34	object <anonymous>
	During manifestation	
Compile error: failed to compile target: openshift4-monitoring
```


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

