### PR TITLE
Only pick up rules for the configured network plugin

### DIFF
--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -10,14 +10,14 @@ local defaultAnnotations = {
 
 local upstreamManifestsFileExclude = function(file) (
   (
-    params.upstreamRules.networkPlugin == 'openshift-sdn' &&
+    params.upstreamRules.networkPlugin != 'ovn-kubernetes' &&
     (
       file == 'ovn-kubernetes-control-plane.yaml' ||
       file == 'ovn-kubernetes.yaml'
     )
   )
   || (
-    params.upstreamRules.networkPlugin == 'ovn-kubernetes' &&
+    params.upstreamRules.networkPlugin != 'openshift-sdn' &&
     file == 'openshift-sdn.yaml'
   )
   || (


### PR DESCRIPTION
Previously, running catalog compilations for different clusters in a shared directory could lead to rules being included erroneously if the corresponding files were downloaded by a previous catalog compilation.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
