### PR TITLE
Support custom network plugins

### DIFF
--- a/class/openshift4-monitoring.yml
+++ b/class/openshift4-monitoring.yml
@@ -89,8 +89,11 @@ parameters:
         source: https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/${openshift4_monitoring:manifests_version}/manifests/0000_90_olm_01-prometheus-rule.yaml
         output_path: dependencies/openshift4-monitoring/manifests/${openshift4_monitoring:manifests_version}/operator-lifecycle-manager.yaml
       - type: https
-        source: https://raw.githubusercontent.com/openshift/cluster-network-operator/${openshift4_monitoring:manifests_version}/bindata/network/${openshift4_monitoring:upstreamRules:networkPlugin}/alert-rules.yaml
-        output_path: dependencies/openshift4-monitoring/manifests/${openshift4_monitoring:manifests_version}/${openshift4_monitoring:upstreamRules:networkPlugin}.yaml
+        source: https://raw.githubusercontent.com/openshift/cluster-network-operator/${openshift4_monitoring:manifests_version}/bindata/network/openshift-sdn/alert-rules.yaml
+        output_path: dependencies/openshift4-monitoring/manifests/${openshift4_monitoring:manifests_version}/openshift-sdn.yaml
+      - type: https
+        source: https://raw.githubusercontent.com/openshift/cluster-network-operator/${openshift4_monitoring:manifests_version}/bindata/network/ovn-kubernetes/alert-rules.yaml
+        output_path: dependencies/openshift4-monitoring/manifests/${openshift4_monitoring:manifests_version}/ovn-kubernetes.yaml
       - type: https
         source: https://raw.githubusercontent.com/openshift/cluster-network-operator/${openshift4_monitoring:manifests_version}/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
         output_path: dependencies/openshift4-monitoring/manifests/${openshift4_monitoring:manifests_version}/ovn-kubernetes-control-plane.yaml

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -35,7 +35,8 @@ type:: string
 default:: `openshift-sdn`
 
 Choose either `openshift-sdn` or `ovn-kubernetes` depending on the installed network plugin.
-If a custom network plugin is used, any other string set as value, will exclude the monitoring rules.
+If a custom network plugin is used, set any other string as the value for this parameter.
+This ensures neither openshift-sdn nor OVN-Kubernetes monitoring rules are deployed.
 
 
 == `upstreamRules.elasticsearchOperator`

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -31,10 +31,11 @@ A dictionary holding the default configuration which should be applied to all co
 == `upstreamRules.networkPlugin`
 
 [horizontal]
-type:: boolean
+type:: string
 default:: `openshift-sdn`
 
 Choose either `openshift-sdn` or `ovn-kubernetes` depending on the installed network plugin.
+If a custom network plugin is used, any other string set as value, will exclude the monitoring rules.
 
 
 == `upstreamRules.elasticsearchOperator`


### PR DESCRIPTION
Download always both network plugin rules sets of openshift-sdn and
ovn-kubernetes. Given any other values, will ignore both rules sets
from being applied.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

