### PR TITLE
Add missing label for custom alerts

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -64,6 +64,7 @@ local ns_patch =
       namespace: params.namespace,
       labels+: {
         role: 'alert-rules',
+        syn: true,
       },
     },
     spec+: {


### PR DESCRIPTION
Withouth the label `syn=true` the alerts will be automatically silenced




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
