### PR TITLE
The syn label should be set on the alert itself

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -64,7 +64,6 @@ local ns_patch =
       namespace: params.namespace,
       labels+: {
         role: 'alert-rules',
-        syn: true,
       },
     },
     spec+: {
@@ -74,6 +73,9 @@ local ns_patch =
           local rnamekey = std.splitLimit(rname, ':', 1);
           params.rules[group_name][rname] {
             [rnamekey[0]]: rnamekey[1],
+            labels+: {
+              syn: 'true',
+            },
           }
           for rname in std.objectFields(params.rules[group_name])
           if params.rules[group_name][rname] != null


### PR DESCRIPTION


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
