### PR TITLE
Add resource management alerts

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -141,7 +141,7 @@ parameters:
               labels: {}
               expr:
                 # How much memory needs to be available to allocate (in bytes)
-                threshold: 'max(kube_node_status_capacity{resource="memory"} * on(node) group_left kube_node_role{role="app"})'
+                threshold: 'max(kube_node_status_allocatable{resource="memory"} * on(node) group_left kube_node_role{role="app"})'
             ExpectTooMuchMemoryRequested:
               enabled: true
               annotations:
@@ -152,7 +152,7 @@ parameters:
               labels: {}
               expr:
                 # How much memory needs to be available to allocate in three days (in bytes)
-                threshold: 'max(kube_node_status_capacity{resource="memory"} * on(node) group_left kube_node_role{role="app"})'
+                threshold: 'max(kube_node_status_allocatable{resource="memory"} * on(node) group_left kube_node_role{role="app"})'
                 # How much of the past to consider for the prediction
                 range: '1d'
                 # How far into the future to predict (in seconds)
@@ -167,7 +167,7 @@ parameters:
               labels: {}
               expr:
                 # How many cpu cores need to be available to allocate
-                threshold: 'max(kube_node_status_capacity{resource="cpu"} * on(node) group_left kube_node_role{role="app"})'
+                threshold: 'max(kube_node_status_allocatable{resource="cpu"} * on(node) group_left kube_node_role{role="app"})'
             ExpectTooMuchCPURequested:
               enabled: true
               annotations:
@@ -178,7 +178,7 @@ parameters:
               labels: {}
               expr:
                 # How many cpu cores need to be available to allocate in three days
-                threshold: 'max(kube_node_status_capacity{resource="cpu"} * on(node) group_left kube_node_role{role="app"})'
+                threshold: 'max(kube_node_status_allocatable{resource="cpu"} * on(node) group_left kube_node_role{role="app"})'
                 # How much of the past to consider for the prediction
                 range: '1d'
                 # How far into the future to predict (in seconds)

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -95,3 +95,150 @@ parameters:
       oc:
         image: quay.io/appuio/oc
         tag: v4.6
+
+
+    capacityAlerts:
+      enabled: false
+      groups:
+        PodCapacity:
+          rules:
+            TooManyPods:
+              enabled: true
+              annotations:
+                message: 'Only {{ $value }} more pods can be started.'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
+                description: 'The cluster is close to the limit of running pods. The cluster might not be able to handle a node failure and might not be able to start new pods. Consider adding new nodes.'
+              for: 30m
+              labels: {}
+              expr:
+                # How many more pods need to be schedulable
+                threshold: 'max(kube_node_status_capacity{resource="pods"} * on(node) group_left kube_node_role{role="app"})'
+            ExpectTooManyPods:
+              enabled: true
+              annotations:
+                message: 'Expected to exceed the threshold of running pods in 3 days'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_ExpectTooManyPods
+                description: 'The cluster is getting close to the limit of running pods. Soon the cluster might not be able to handle a node failure and might not be able to start new pods. Consider adding new nodes.'
+              for: 1h
+              labels: {}
+              expr:
+                # How many more pods need to be schedulable in three days
+                threshold: 'max(kube_node_status_capacity{resource="pods"} * on(node) group_left kube_node_role{role="app"})'
+                # How much of the past to consider for the prediction
+                range: '1d'
+                # How far into the future to predict (in seconds)
+                predict: '3*24*60*60'
+
+        ResourceRequests:
+          rules:
+            TooMuchMemoryRequested:
+              enabled: true
+              annotations:
+                message: 'Only {{ $value }} memory left for new pods.'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
+                description: 'The cluster is close to asigning all memory to running pods. The cluster might not be able to handle a node failure and might not be able to start new pods. Consider adding new nodes.'
+              for: 30m
+              labels: {}
+              expr:
+                # How much memory needs to be available to allocate (in bytes)
+                threshold: 'max(kube_node_status_capacity{resource="memory"} * on(node) group_left kube_node_role{role="app"})'
+            ExpectTooMuchMemoryRequested:
+              enabled: true
+              annotations:
+                message: 'Expected to exceed the threshold of requested memory in 3 days'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_ExpectTooMuchMemoryRequested
+                description: 'The cluster is getting close to asigning all memory to running pods. Soon the cluster might not be able to handle a node failure and might not be able to start new pods. Consider adding new nodes.'
+              for: 1h
+              labels: {}
+              expr:
+                # How much memory needs to be available to allocate in three days (in bytes)
+                threshold: 'max(kube_node_status_capacity{resource="memory"} * on(node) group_left kube_node_role{role="app"})'
+                # How much of the past to consider for the prediction
+                range: '1d'
+                # How far into the future to predict (in seconds)
+                predict: '3*24*60*60'
+            TooMuchCPURequested:
+              enabled: true
+              annotations:
+                message: 'Only {{ $value }} cpu cores left for new pods.'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
+                description: 'The cluster is close to asigning all CPU resources to running pods. The cluster might not be able to handle a node failure and might soon not be able to start new pods. Consider adding new nodes.'
+              for: 30m
+              labels: {}
+              expr:
+                # How many cpu cores need to be available to allocate
+                threshold: 'max(kube_node_status_capacity{resource="cpu"} * on(node) group_left kube_node_role{role="app"})'
+            ExpectTooMuchCPURequested:
+              enabled: true
+              annotations:
+                message: 'Expected to exceed the threshold of requested CPU resources in 3 days'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_ExpectTooMuchCPURequested
+                description: 'The cluster is getting close to asigning all CPU cores to running pods. Soon the cluster might not be able to handle a node failure and might not be able to start new pods. Consider adding new nodes.'
+              for: 1h
+              labels: {}
+              expr:
+                # How many cpu cores need to be available to allocate in three days
+                threshold: 'max(kube_node_status_capacity{resource="cpu"} * on(node) group_left kube_node_role{role="app"})'
+                # How much of the past to consider for the prediction
+                range: '1d'
+                # How far into the future to predict (in seconds)
+                predict: '3*24*60*60'
+
+        MemoryCapacity:
+          rules:
+            ClusterLowOnMemory:
+              enabled: true
+              annotations:
+                message: 'Only {{ $value }} free memory on Worker Nodes.'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
+                description: 'The cluster is close to using all of its memory. The cluster might not be able to handle a node failure or load spikes. Consider adding new nodes.'
+              for: 30m
+              labels: {}
+              expr:
+                # How much memory needs to be free over all worker nodes (in bytes)
+                threshold: 'max(kube_node_status_capacity{resource="memory"} * on(node) group_left kube_node_role{role="app"})'
+            ExpectClusterLowOnMemory:
+              enabled: true
+              annotations:
+                message: 'Cluster expected to run low on memory in 3 days'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ExpectClusterMemoryUsageHigh
+                description: 'The cluster is getting close to using all of its memory. Soon the cluster might not be able to handle a node failure or load spikes. Consider adding new nodes.'
+              for: 1h
+              labels: {}
+              expr:
+                # How much memory needs to be over all worker nodes in three days (in bytes)
+                threshold: 'max(kube_node_status_capacity{resource="memory"} * on(node) group_left kube_node_role{role="app"})'
+                # How much of the past to consider for the prediction
+                range: '1d'
+                # How far into the future to predict (in seconds)
+                predict: '3*24*60*60'
+
+        CpuCapacity:
+          rules:
+            ClusterCpuUsageHigh:
+              enabled: true
+              annotations:
+                message: 'Only {{ $value }} idle cpu cores accross cluster.'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
+                description: 'The cluster is close to using up all CPU resources. The cluster might not be able to handle a node failure or load spikes. Consider adding new nodes.'
+              for: 2h
+              labels: {}
+              expr:
+                # How many cpu cores need to be available to allocate
+                threshold: 'max(kube_node_status_capacity{resource="cpu"} * on(node) group_left kube_node_role{role="app"})'
+
+            ExpectClusterCpuUsageHigh:
+              enabled: true
+              annotations:
+                message: 'Cluster expected to run low on available CPU resources in 3 days'
+                runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ExpectClusterCpuUsageHigh
+                description: 'The cluster is getting close to using up all CPU resources. The cluster might soon not be able to handle a node failure or load spikes. Consider adding new nodes.'
+              for: 2h
+              labels: {}
+              expr:
+                # How many cpu cores need to be idle
+                threshold: 'max(kube_node_status_capacity{resource="cpu"} * on(node) group_left kube_node_role{role="app"})'
+                # How much of the past to consider for the prediction
+                range: '1d'
+                # How far into the future to predict (in seconds)
+                predict: '3*24*60*60'

--- a/component/capacity.libsonnet
+++ b/component/capacity.libsonnet
@@ -1,0 +1,89 @@
+local monitoringOperator = import 'cluster-monitoring-operator/main.jsonnet';
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local prom = import 'lib/prom.libsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_monitoring;
+local customAnnotations = params.alerts.customAnnotations;
+local defaultAnnotations = {
+  syn_component: inv.parameters._instance,
+};
+
+local alertLabels = {
+  syn: 'true',
+  syn_component: 'openshift4-monitoring',
+  severity: 'warning',
+};
+
+local predict(indicator, range='1d', resolution='1h', predict='3*24*60*60') =
+  'predict_linear(avg_over_time(%(indicator)s[%(range)s:%(resolution)s])[%(range)s:%(resolution)s], %(predict)s)' %
+  { indicator: indicator, range: range, resolution: resolution, predict: predict };
+
+local filterWorkerNodes(metric, workerRole='app', nodeLabel='node') =
+  '%(metric)s * on(%(nodeLabel)s) group_left label_replace(kube_node_role{role="%(workerRole)s"}, "%(nodeLabel)s", "$1", "node", "(.+)")' %
+  { metric: metric, nodeLabel: nodeLabel, workerRole: workerRole };
+
+local resourceCapacity(resource) = 'sum(%s)' % filterWorkerNodes('kube_node_status_capacity{resource="%s"}' % resource);
+local resourceRequests(resource) = 'sum(%s)' % filterWorkerNodes('kube_pod_resource_request{resource="%s"}' % resource);
+
+local memoryCapacity = resourceCapacity('memory');
+local memoryRequests = resourceRequests('memory');
+local memoryFree = 'sum(%s)' % filterWorkerNodes('node_memory_MemAvailable_bytes', nodeLabel='instance');
+
+local cpuCapacity = resourceCapacity('cpu');
+local cpuRequests = resourceRequests('cpu');
+local cpuIdle = 'sum(%s)' % filterWorkerNodes('rate(node_cpu_seconds_total{mode="idle"}[15m])', nodeLabel='instance');
+
+local podCapacity = resourceCapacity('pods');
+local podCount = 'sum(%s)' % filterWorkerNodes('kubelet_running_pods');
+
+local exprMap = {
+  TooManyPods: function(arg) '%s - %s < %s' % [ podCapacity, podCount, arg.threshold ],
+  ExpectTooManyPods: function(arg) '%s - %s < %s' % [ podCapacity, predict(podCount, range=arg.range, predict=arg.predict), arg.threshold ],
+
+  TooMuchMemoryRequested: function(arg) '%s - %s < %s' % [ memoryCapacity, memoryRequests, arg.threshold ],
+  ExpectTooMuchMemoryRequested: function(arg) '%s - %s < %s' % [ memoryCapacity, predict(memoryRequests, range=arg.range, predict=arg.predict), arg.threshold ],
+  TooMuchCPURequested: function(arg) '%s - %s < %s' % [ cpuCapacity, cpuRequests, arg.threshold ],
+  ExpectTooMuchCPURequested: function(arg) '%s - %s < %s' % [ cpuCapacity, predict(cpuRequests, range=arg.range, predict=arg.predict), arg.threshold ],
+
+  ClusterLowOnMemory: function(arg) '%s < %s' % [ memoryFree, arg.threshold ],
+  ExpectClusterLowOnMemory: function(arg) '%s < %s' % [ predict(memoryFree, range=arg.range, predict=arg.predict), arg.threshold ],
+
+  ClusterCpuUsageHigh: function(arg) '%s < %s' % [ cpuIdle, arg.threshold ],
+  ExpectClusterCpuUsageHigh: function(arg) '%s < %s' % [ predict(cpuIdle, range=arg.range, predict=arg.predict), arg.threshold ],
+};
+
+{
+  rules: prom.PrometheusRule('capacity') {
+    metadata+: {
+      annotations+: defaultAnnotations,
+      namespace: params.namespace,
+    },
+    spec+: {
+      groups: std.filter(function(x) std.length(x.rules) > 0, [
+        {
+          local group = params.capacityAlerts.groups[alertGroupName],
+          name: 'syn-' + alertGroupName,
+          rules: [
+            group.rules[ruleName] {
+              alert: 'SYN_' + ruleName,
+              enabled:: true,
+              labels: alertLabels + super.labels,
+              annotations: defaultAnnotations + super.annotations,
+              expr:
+                if std.objectHas(super.expr, 'raw') then
+                  super.expr.raw
+                else
+                  exprMap[ruleName](super.expr),
+            }
+            for ruleName in std.objectFields(group.rules)
+            if group.rules[ruleName].enabled
+          ],
+        }
+        for alertGroupName in std.objectFields(params.capacityAlerts.groups)
+      ]),
+    },
+  },
+}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -8,6 +8,7 @@ local inv = kap.inventory();
 local params = inv.parameters.openshift4_monitoring;
 
 local rules = import 'rules.jsonnet';
+local capacity = import 'capacity.libsonnet';
 
 local ns =
   if params.namespace != 'openshift-monitoring' then
@@ -72,6 +73,7 @@ local ns_patch =
   },
   prometheus_rules: rules,
   silence: import 'silence.jsonnet',
+  [if params.capacityAlerts.enabled then 'capacity_rules']: capacity.rules,
 } + {
   [group_name + '_rules']: prom.PrometheusRule(group_name) {
     metadata+: {

--- a/docs/modules/ROOT/pages/explanations/resource_management.adoc
+++ b/docs/modules/ROOT/pages/explanations/resource_management.adoc
@@ -39,7 +39,7 @@ max(
 
 .**Expect too many pods**
 
-We alert if we predict to be unable to run all currently running pods in three days if the largest worker node crashes.
+We alert if we predict that we'll be unable to run all pods if the largest worker node crashes in three days, assuming linear growth of running pods based on the change in running pods over the last 24 hours.
 ```
 // The pod capacity of all worker nodes
 sum(
@@ -71,7 +71,7 @@ The combined memory and CPU requests of all workloads is another good indicator.
 If the combined requests are higher than the actual resources, some workloads will no be scheduled.
 
 The component provides four resource request related alerts.
-They alert if there isn't enough CPU or memory capacity if the largest worker node disappears or if we predict that the cluster will exceed this threshold in three days.,
+They alert if there isn't enough CPU or memory capacity if the largest worker node disappears or if we predict that the cluster will exceed this threshold in three days.
 
 .**Too much memory requested**
 ```
@@ -256,10 +256,10 @@ max(
 
 [NOTE]
 ====
-By default for predictions we take the one day moving average over one day to predict three days into the future.
+By default, we use the one day moving average over one day for queries which predict three days into the future.
 Without the moving average the prediction is influenced too much by temporary changes.
 
-If for example an environment is updated using a blue-green deployment, without the moving average the alert will see this sudden increase in resource usage, interpolate this for three days and will fire.
+For example, if an environment is updated using a blue-green deployment, without the moving average the alert will see this sudden increase in resource usage, extrapolate the increase over three days and will fire, generating a false-positive alert.
 The moving average gives us a better indication of the long term trend.
 ====
 

--- a/docs/modules/ROOT/pages/explanations/resource_management.adoc
+++ b/docs/modules/ROOT/pages/explanations/resource_management.adoc
@@ -75,9 +75,9 @@ They alert if there isn't enough CPU or memory capacity if the largest worker no
 
 .**Too much memory requested**
 ```
-// The memory capacity of all worker nodes
+// The allocatable memory on all worker nodes
 sum(
-  kube_node_status_capacity{resource="memory"}
+  kube_node_status_allocatable{resource="memory"}
     * on(node) group_left kube_node_role{role="app"}
 )
 -
@@ -87,17 +87,17 @@ sum(
     * on(node) group_left kube_node_role{role="app"}
 )
 <
-// The memory capacity of the largest worker node
+// The allocatable memory on the largest worker node
 max(
-  kube_node_status_capacity{resource="memory"}
+  kube_node_status_allocatable{resource="memory"}
     * on(node) group_left kube_node_role{role="app"}
 )
 ```
 .**Expect too much memory to be requested**
 ```
-// The memory capacity of all worker nodes
+// The allocatable memory on all worker nodes
 sum(
-  kube_node_status_capacity{resource="memory"}
+  kube_node_status_allocatable{resource="memory"}
     * on(node) group_left kube_node_role{role="app"}
 )
 -
@@ -111,18 +111,18 @@ predict_linear(
   )[1d:1h],
 3*24*60*60)
 <
-// The memory capacity of the largest worker node
+// The allocatable memory on the largest worker node
 max(
-  kube_node_status_capacity{resource="memory"}
+  kube_node_status_allocatable{resource="memory"}
     * on(node) group_left kube_node_role{role="app"}
 )
 ```
 
 .**Too much CPU requested**
 ```
-// The CPU capacity of all worker nodes
+// The allocatable CPU cores on all worker nodes
 sum(
-  kube_node_status_capacity{resource="cpu"}
+  kube_node_status_allocatable{resource="cpu"}
     * on(node) group_left kube_node_role{role="app"}
 )
 -
@@ -132,17 +132,17 @@ sum(
     * on(node) group_left kube_node_role{role="app"}
 )
 <
-// The CPU capacity of the largest worker node
+// The allocatable CPU cores on largest worker node
 max(
-  kube_node_status_capacity{resource="cpu"}
+  kube_node_status_allocatable{resource="cpu"}
     * on(node) group_left kube_node_role{role="app"}
 )
 ```
 .**Expect too much CPU to be requested**
 ```
-// The CPU capacity of all worker nodes
+// The allocatable CPU cores on all worker nodes
 sum(
-  kube_node_status_capacity{resource="cpu"}
+  kube_node_status_allocatable{resource="cpu"}
     * on(node) group_left kube_node_role{role="app"}
 )
 -
@@ -156,9 +156,9 @@ predict_linear(
   )[1d:1h],
 3*24*60*60)
 <
-// The CPU capacity of the largest worker node
+// The allocatable CPU cores on largest worker node
 max(
-  kube_node_status_capacity{resource="cpu"}
+  kube_node_status_allocatable{resource="cpu"}
     * on(node) group_left kube_node_role{role="app"}
 )
 ```

--- a/docs/modules/ROOT/pages/explanations/resource_management.adoc
+++ b/docs/modules/ROOT/pages/explanations/resource_management.adoc
@@ -272,7 +272,7 @@ There are some metrics that might be considered as an indicator for cluster capa
 Similarly to the total memory and CPU requests of workloads one could look at the total memory and CPU limits as an indicator for cluster capacity.
 However in almost all cases the total limits are a lot higher than the actual capacity of the cluster.
 This is normal and this overprovisioning is one of the advantages of Kubernetes.
-It0s hard to say what level of overprovisioning is OK and what's not, so observing the actual resource usage is more effective.
+It's hard to say what level of overprovisioning is OK and what's not, so observing the actual resource usage is more effective.
 
 .**High Node Usage / System Imbalance**
 

--- a/docs/modules/ROOT/pages/explanations/resource_management.adoc
+++ b/docs/modules/ROOT/pages/explanations/resource_management.adoc
@@ -1,0 +1,289 @@
+= Resource Management
+
+This component can introduce multiple alerts that should notify you if the cluster is about to run out of resources and needs to be resized.
+The provided alerts only focus on worker nodes and aim to always be actionable.
+
+== Indicators
+
+=== Pod Count
+
+A high pod count is a good indicator that we need to add more worker nodes.
+It's only recommended to run up to 110 pods per node.
+Additional pods are unable to be scheduled.
+
+The component provides two pod count related alerts:
+
+.**Too many pods**
+
+We alert if we're unable to run all currently running pods if the largest worker node crashes.
+
+```
+// The pod capacity of all worker nodes
+sum(
+  kube_node_status_capacity{resource="pods"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+-
+// The number of running pods on all worker nodes
+sum(
+  kubelet_running_pods
+    * on(node) group_left kube_node_role{role="app"},
+)
+<
+// The pod capacity of the largest worker node
+max(
+  kube_node_status_capacity{resource="pods"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+
+.**Expect too many pods**
+
+We alert if we predict to be unable to run all currently running pods in three days if the largest worker node crashes.
+```
+// The pod capacity of all worker nodes
+sum(
+  kube_node_status_capacity{resource="pods"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+-
+// The predicted number of running pods on all worker nodes in 3 days
+predict_linear(
+  // Take the moving average over a day to prevent flapping alerts
+  avg_over_time(
+    sum(
+      kubelet_running_pods
+        * on(node) group_left kube_node_role{role="app"},
+    )[1d:1h]
+  )[1d:1h],
+3*24*60*60)
+<
+// The pod capacity of the largest worker node
+max(
+  kube_node_status_capacity{resource="pods"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+
+=== Memory/CPU requests
+
+The combined memory and CPU requests of all workloads is another good indicator.
+If the combined requests are higher than the actual resources, some workloads will no be scheduled.
+
+The component provides four resource request related alerts.
+They alert if there isn't enough CPU or memory capacity if the largest worker node disappears or if we predict that the cluster will exceed this threshold in three days.,
+
+.**Too much memory requested**
+```
+// The memory capacity of all worker nodes
+sum(
+  kube_node_status_capacity{resource="memory"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+-
+// The memory requests on all worker nodes
+sum(
+  kube_pod_resource_request{resource="memory"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+<
+// The memory capacity of the largest worker node
+max(
+  kube_node_status_capacity{resource="memory"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+.**Expect too much memory to be requested**
+```
+// The memory capacity of all worker nodes
+sum(
+  kube_node_status_capacity{resource="memory"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+-
+// The predicted memory requests on all worker nodes in three days
+predict_linear(
+  avg_over_time(
+    sum(
+      kube_pod_resource_request{resource="memory"}
+        * on(node) group_left kube_node_role{role="app"}
+    )[1d:1h]
+  )[1d:1h],
+3*24*60*60)
+<
+// The memory capacity of the largest worker node
+max(
+  kube_node_status_capacity{resource="memory"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+
+.**Too much CPU requested**
+```
+// The CPU capacity of all worker nodes
+sum(
+  kube_node_status_capacity{resource="cpu"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+-
+// The CPU requests on all worker nodes
+sum(
+  kube_pod_resource_request{resource="cpu"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+<
+// The CPU capacity of the largest worker node
+max(
+  kube_node_status_capacity{resource="cpu"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+.**Expect too much CPU to be requested**
+```
+// The CPU capacity of all worker nodes
+sum(
+  kube_node_status_capacity{resource="cpu"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+-
+// The predicted CPU requests on all worker nodes in three days
+predict_linear(
+  avg_over_time(
+    sum(
+      kube_pod_resource_request{resource="cpu"}
+        * on(node) group_left kube_node_role{role="app"}
+    )[1d:1h]
+  )[1d:1h],
+3*24*60*60)
+<
+// The CPU capacity of the largest worker node
+max(
+  kube_node_status_capacity{resource="cpu"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+
+=== Memory Usage
+
+Low available memory is a good indicator that the cluster needs to be resized.
+If there is no available memory, the cluster won't be able to schedule new workload and will eventually start to OOM kill workloads
+
+The component provides two memory usage related alerts:
+
+.**Workers low on memory memory**
+
+We alert if there is less memory available than the largest worker node.
+
+```
+sum(
+  // The unused memory for every node with role "app"
+  node_memory_MemAvailable_bytes
+    * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")
+)
+<
+// The capacity of the largest worker node
+max(kube_node_status_capacity{resource="memory"}
+  * on(node) group_left kube_node_role{role="app"})
+```
+
+.**Workers expected run out of memory**
+
+We alert if we expect that in three days less memory will be available than the largest worker node.
+
+```
+
+// Predict in 3 days
+predict_linear(
+  // Take the moving average over a day to prevent flapping alerts
+  avg_over_time(
+    sum(
+      // The unused memory for every node with role "app"
+      node_memory_MemAvailable_bytes *
+          on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")
+    )[1d:1h]
+  )[1d:1h],
+3*24*60*60)
+<
+// The capacity of the largest worker node
+max(
+  kube_node_status_capacity{resource="memory"}
+    * on(node) group_left kube_node_role{role="app"}
+  )
+```
+
+
+=== CPU Usage
+
+High CPU usage can also be an indicator that the cluster is too small.
+
+The component provides two CPU usage related alerts:
+
+.**Workers CPU usage high**
+We alert if there is fewer idle CPU cores than the largest worker node has.
+```
+sum(
+  // The average number of idle CPUs over 15 minutes for all worker nodes
+  rate(node_cpu_seconds_total{mode="idle"}[15m])
+    * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)"))
+<
+// The capacity of the largest worker node
+max(
+  kube_node_status_capacity{resource="cpu"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+
+.**Workers CPU usage expected to be high**
+We alert if we predict to have fewer idle CPU cores than the largest worker node has in three days.
+```
+// The predicted number idle CPUs for all worker nodes in 3 days
+predict_linear(
+  // Take the moving average over a day to prevent flapping alerts
+  avg_over_time(
+    sum(
+      rate(node_cpu_seconds_total{mode="idle"}[15m])
+        * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")
+    )[1d:1h]
+  )[1d:1h],
+3*24*60*60)
+<
+// The capacity of the largest worker node
+max(
+  kube_node_status_capacity{resource="cpu"}
+    * on(node) group_left kube_node_role{role="app"}
+)
+```
+
+[NOTE]
+====
+By default for predictions we take the one day moving average over one day to predict three days into the future.
+Without the moving average the prediction is influenced too much by temporary changes.
+
+If for example an environment is updated using a blue-green deployment, without the moving average the alert will see this sudden increase in resource usage, interpolate this for three days and will fire.
+The moving average gives us a better indication of the long term trend.
+====
+
+== Non-Indicators
+
+There are some metrics that might be considered as an indicator for cluster capacity, but have intentionally not been added as alert rules, as they're either too noisy or not actionable.
+
+.**Memory/CPU limits**
+
+Similarly to the total memory and CPU requests of workloads one could look at the total memory and CPU limits as an indicator for cluster capacity.
+However in almost all cases the total limits are a lot higher than the actual capacity of the cluster.
+This is normal and this overprovisioning is one of the advantages of Kubernetes.
+It0s hard to say what level of overprovisioning is OK and what's not, so observing the actual resource usage is more effective.
+
+.**High Node Usage / System Imbalance**
+
+We also intentionally didn't add alerts on a node level.
+It might sound like a good idea to make an alert if for example the memory of a node is maxed out.
+However such an alert isn't actionable.
+Such a _system imbalance_ can be solved by restarting pods, however Kubernetes will do this on its own eventually.
+
+.**Non Worker Node Alerts**
+
+The capacity alerts are only for the worker nodes running customer workloads.
+Monitoring system nodes is out of scope and should be handled by other alerts.
+
+The rational for this is that resource usage of system components should rarely change on its own and we very rarely should need to add additional master or infrastructure nodes.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -294,7 +294,8 @@ The dictionary will be transformed into a `PrometheusRule` object by the compone
 The component provides 10 alerts that are grouped in four groups.
 You can disable or modify each of these alert rules individually.
 The fields in these rules will be added to the final `PrometheusRule`, with the exception of `expr`.
-The `expr` field contains parameters for the default alert rule but can be overwritten using the `expr.raw` (see example below).
+The `expr` field contains fields which can be used to tune the default alert rule.
+Alternatively the default rule can be completely overwritten by setting the `expr.raw` field (see example below).
 See xref:explanations/resource_management.adoc[Resource Management] for an explanation for every alert rule.
 
 Example:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -281,6 +281,61 @@ default:: 3
 
 Number of successful jobs to keep.
 
+== `capacityAlerts`
+
+[horizontal]
+type:: dict
+
+This parameter allows users to enable and configure alerts for capacity management.
+The capacity alerts are disabled by default and can be enabled by setting the key `capacityAlerts.enabled` to `true`.
+
+The dictionary will be transformed into a `PrometheusRule` object by the component.
+
+The component provides 10 alerts that are grouped in four groups.
+You can disable or modify each of these alert rules individually.
+The fields in these rules will be added to the final `PrometheusRule`, with the exception of `expr`.
+The `expr` field contains parameters for the default alert rule but can be overwritten using the `expr.raw` (see example below).
+See xref:explanations/resource_management.adoc[Resource Management] for an explanation for every alert rule.
+
+Example:
+
+[source,yaml]
+---
+capacityAlerts:
+  enabled: true <1>
+  groups:
+    PodCapacity:
+      rules:
+        TooManyPods:
+          annotations:
+            message: 'The number of pods is too damn high' <2>
+          for: 3h <3>
+        ExpectTooManyPods:
+          expr: <4>
+            range: '2d'
+            predict: '5*24*60*60'
+
+    ResourceRequests:
+      rules:
+        TooMuchMemoryRequested:
+          enabled: true
+          expr:
+            raw: sum(kube_pod_resource_request{resource="memory"}) > 9000*1024*1024*1024 <5>
+    CpuCapacity:
+      rules:
+        ClusterCpuUsageHigh:
+          enabled: false <6>
+        ExpectClusterCpuUsageHigh:
+          enabled: false <6>
+---
+<1> Enables capacity alerts
+<2> Changes the alert message for the pod capacity alert
+<3> Only alerts for pod capacity if it fires for 3 hours
+<4> Change the pod count prediction to look at the last two days and predict the value in five days
+<5> Completely overrides the default alert rule and alerts if the total memory request is over 9000 GB
+<6> Disables both CPU capacity alert rules
+
+
 == `rules`
 
 [horizontal]
@@ -313,6 +368,7 @@ rules:
       labels:
         source: https://git.vshn.net/swisscompks/syn-tenant-repo/-/blob/master/common.yml
         severity: devnull
+---
 
 == Example
 

--- a/docs/modules/ROOT/pages/runbooks/cpucapacity.adoc
+++ b/docs/modules/ROOT/pages/runbooks/cpucapacity.adoc
@@ -1,0 +1,104 @@
+= Alert Group: syn-CpuCapacity
+
+We provide two rules to notice if a cluster has high CPU utilization.
+If a cluster has consistently high CPU utilization workload latency might increase and operations might timeout.
+
+== Alert Rule: SYN_ClusterCpuUsageHigh [[SYN_ClusterCpuUsageHigh]]
+
+=== icon:glasses[] Overview
+
+This alert means that the total CPU utilization over all worker nodes is high.
+By default it will fire if the number of idle cores is less than the core count of the largest worker node for more than two hours.
+
+This means if you receive this alert in case of a woker node failure the cluster will likely experience high latency.
+After verifying the alert you should consider adding more CPU capacity.
+
+=== icon:search[] Investigate
+
+* Verify the alert
+** Verify that the reported load is correct.
++
+[source,shell]
+----
+kubectl top nodes
+----
++
+If not there might be a bug in the alert rule.
+Please disable this alert and open an issue for this component.
+** Check if there is a sudden increase in CPU usage that indicate that this might be temporary or caused by a misbehaving workload.
+* Either add more worker nodes or resize existing worker nodes according to the install https://kb.vshn.ch/oc4/index.html[instructions for your cloud]
+
+=== icon:wrench[] Tune
+
+If this alert is non actionable, noisy, or was raised too late you might want to tune it.
+
+Through the component parameters you have the option modify the alert threshold, change for how long it needs to be firing until you are alerted, or disable it outright.
+In the example below will adapt the rule to only alert after four hours and change the threshold to 4 cores.
+
+[source,yaml]
+----
+capacityAlerts:
+  groups:
+    CpuCapacity:
+      rules:
+        ClusterCpuUsageHigh:
+          enabled: true
+          for: 4h
+          expr:
+            threshold: '4' <1>
+----
+<1> The threshold can be an arbitrary promql expression
+
+== Alert Rule: SYN_ExpectClusterCpuUsageHigh [[SYN_ExpectClusterCpuUsageHigh]]
+
+=== icon:glasses[] Overview
+
+This alert means that we expect the total CPU utilization over all worker nodes might soon be high.
+By default this alert will fire if we expect the number of idle cores to less than the core count of the largest worker node in three days.
+
+This means if you receive this alert the cluster might soon experience degraded workload performance in case of a worker node failure.
+After verifying the alert you should consider adding more CPU capacity in the next days.
+
+=== icon:search[] Investigate
+
+* Look at the source of this alert in Prometheus
+** Does the prediction look realistic?
+** Compare it to the graph without the `predict_linear`
+** If there is any doubt in the prediction, monitor this graph for the next hours or days
+* Check the actual CPU usage on each worker node
++
+[source,shell]
+----
+kubectl top nodes
+----
++
+If the number is widely different than the prediction, the alert is probably not actionable.
+* Check if there is a sudden increase in CPU usage that indicate that this might be temporary or caused by a misbehaving workload.
+* Add one or more worker nodes or resize existing worker nodes according to the install https://kb.vshn.ch/oc4/index.html[instructions for your cloud]
+
+
+=== icon:wrench[] Tune
+
+If this alert isn't actionable, noisy, or was raised too late you might want to tune it.
+
+Through the component parameters you have the option tune the alert rule.
+You can modify the threshold, change for how long it needs to be firing until you are alerted, how far into the future to predict, or disable it outright.
+
+In the example below will adapt the rule so that it will alert if we expect that all CPU cores will be utilized in 5 days, but only if it fired for 12h.
+
+[source,yaml]
+----
+capacityAlerts:
+  groups:
+    CpuCapacity:
+      rules:
+        ClusterCpuUsageHigh:
+          enabled: true
+          for: 12h
+          expr:
+            threshold: '0' <1>
+            predict: '5*24*60*60' <2>
+----
+<1> The threshold can be an arbitrary promql expression
+<2> How far into the future to predict in seconds
+

--- a/docs/modules/ROOT/pages/runbooks/cpucapacity.adoc
+++ b/docs/modules/ROOT/pages/runbooks/cpucapacity.adoc
@@ -1,17 +1,17 @@
 = Alert Group: syn-CpuCapacity
 
 We provide two rules to notice if a cluster has high CPU utilization.
-If a cluster has consistently high CPU utilization workload latency might increase and operations might timeout.
+If a cluster has consistently high CPU utilization, workload latency might increase and operations might time out.
 
 == Alert Rule: SYN_ClusterCpuUsageHigh [[SYN_ClusterCpuUsageHigh]]
 
 === icon:glasses[] Overview
 
-This alert means that the total CPU utilization over all worker nodes is high.
-By default it will fire if the number of idle cores is less than the core count of the largest worker node for more than two hours.
+This alert indicates that the total CPU utilization over all worker nodes is high.
+By default, it will fire if the number of idle cores is less than the core count of the largest worker node for more than two hours.
 
-This means if you receive this alert in case of a woker node failure the cluster will likely experience high latency.
-After verifying the alert you should consider adding more CPU capacity.
+If you receive this alert, a worker node failure in the cluster is likely to cause high latency for customer workloads.
+After verifying that the cluster's CPU utilization is high, you should consider adding more CPU capacity.
 
 === icon:search[] Investigate
 
@@ -23,14 +23,14 @@ After verifying the alert you should consider adding more CPU capacity.
 kubectl top nodes
 ----
 +
-If not there might be a bug in the alert rule.
-Please disable this alert and open an issue for this component.
+If the load reported by `top nodes` doesn't appear to be particularly high, there might be a bug in the alert rule.
+If that's the case, please disable this alert and open an issue for this component.
 ** Check if there is a sudden increase in CPU usage that indicate that this might be temporary or caused by a misbehaving workload.
 * Either add more worker nodes or resize existing worker nodes according to the install https://kb.vshn.ch/oc4/index.html[instructions for your cloud]
 
 === icon:wrench[] Tune
 
-If this alert is non actionable, noisy, or was raised too late you might want to tune it.
+If this alert isn't actionable, noisy, or was raised too late you might want to tune it.
 
 Through the component parameters you have the option modify the alert threshold, change for how long it needs to be firing until you are alerted, or disable it outright.
 In the example below will adapt the rule to only alert after four hours and change the threshold to 4 cores.
@@ -47,17 +47,17 @@ capacityAlerts:
           expr:
             threshold: '4' <1>
 ----
-<1> The threshold can be an arbitrary promql expression
+<1> The threshold can be an arbitrary PromQL expression
 
 == Alert Rule: SYN_ExpectClusterCpuUsageHigh [[SYN_ExpectClusterCpuUsageHigh]]
 
 === icon:glasses[] Overview
 
-This alert means that we expect the total CPU utilization over all worker nodes might soon be high.
-By default this alert will fire if we expect the number of idle cores to less than the core count of the largest worker node in three days.
+This alert indicates that we expect the total CPU utilization over all worker nodes to become high in the next days.
+By default, this alert will fire if we expect the number of idle cores to less than the core count of the largest worker node in three days.
 
-This means if you receive this alert the cluster might soon experience degraded workload performance in case of a worker node failure.
-After verifying the alert you should consider adding more CPU capacity in the next days.
+If you receive this alert, the cluster might soon experience degraded workload performance in case of a worker node failure.
+After verifying the CPU utilization growth, you should consider adding more CPU capacity in the next days.
 
 === icon:search[] Investigate
 

--- a/docs/modules/ROOT/pages/runbooks/memorycapacity.adoc
+++ b/docs/modules/ROOT/pages/runbooks/memorycapacity.adoc
@@ -7,11 +7,11 @@ If a cluster uses up most of its memory some workload might start to get termina
 
 === icon:glasses[] Overview
 
-This alert means that the total memory usage over all worker nodes is high.
-By default it will fire if the amount unused memory is less than the memory capacity of the largest worker node.
+This alert indicates that the total memory usage over all worker nodes is high.
+By default, it will fire if the amount unused memory is less than the memory capacity of the largest worker node.
 
-This means if you receive this alert in case of a woker node failure the cluster will likely start to OOM kill workloads.
-After verifying the alert you should consider adding more memory capacity.
+If you receive this alert, a worker node failure in the cluster will likely cause customer workloads to be OOM killed.
+After verifying that the cluster's memory utilization is high, you should consider adding more memory capacity.
 
 === icon:search[] Investigate
 
@@ -23,14 +23,14 @@ After verifying the alert you should consider adding more memory capacity.
 kubectl top nodes
 ----
 +
-If not there might be a bug in the alert rule.
-Please disable this alert and open an issue for this component.
+If the memory utilization reported by `top nodes` doesn't appear to be particularly high, there might be a bug in the alert rule.
+If that's the case, please disable this alert and open an issue for this component.
 ** Check if there is a sudden increase in memory usage that indicate that this might be temporary or caused by a misbehaving workload.
 * Either add more worker nodes or resize existing worker nodes according to the install https://kb.vshn.ch/oc4/index.html[instructions for your cloud]
 
 === icon:wrench[] Tune
 
-If this alert is non actionable, noisy, or was raised too late you might want to tune it.
+If this alert isn't actionable, noisy, or was raised too late you might want to tune it.
 
 Through the component parameters you have the option modify the alert threshold, change for how long it needs to be firing until you are alerted, or disable it outright.
 In the example below will adapt the rule to only alert after four hours and change the threshold to 128 GB.
@@ -53,11 +53,11 @@ capacityAlerts:
 
 === icon:glasses[] Overview
 
-This alert means that we expect the total Memory utilization over all worker nodes might soon be high.
-By default this alert will fire if we expect the amount of unused memory to be less than the memory capacity of the largest worker node in three days.
+This alert indicates that the total memory utilization over all worker nodes may become high over the next days.
+By default, this alert will fire if we expect the amount of unused memory to be less than the memory capacity of the largest worker node in three days.
 
-This means if you receive this alert the cluster might soon not be able to keep all workloads running in case of a worker node failure.
-After verifying the alert you should consider adding more memory capacity in the next days.
+If you receive this alert, the cluster might soon not be able to keep all workloads running in case of a worker node failure.
+After verifying the memory utilization growth, you should consider adding more memory capacity in the next days.
 
 === icon:search[] Investigate
 

--- a/docs/modules/ROOT/pages/runbooks/memorycapacity.adoc
+++ b/docs/modules/ROOT/pages/runbooks/memorycapacity.adoc
@@ -1,0 +1,104 @@
+= Alert Group: syn-MemoryCapacity
+
+We provide two rules to notice if a cluster has high memory usage.
+If a cluster uses up most of its memory some workload might start to get terminated.
+
+== Alert Rule: SYN_ClusterMemoryUsageHigh [[SYN_ClusterMemoryUsageHigh]]
+
+=== icon:glasses[] Overview
+
+This alert means that the total memory usage over all worker nodes is high.
+By default it will fire if the amount unused memory is less than the memory capacity of the largest worker node.
+
+This means if you receive this alert in case of a woker node failure the cluster will likely start to OOM kill workloads.
+After verifying the alert you should consider adding more memory capacity.
+
+=== icon:search[] Investigate
+
+* Verify the alert
+** Verify that the reported load is correct.
++
+[source,shell]
+----
+kubectl top nodes
+----
++
+If not there might be a bug in the alert rule.
+Please disable this alert and open an issue for this component.
+** Check if there is a sudden increase in memory usage that indicate that this might be temporary or caused by a misbehaving workload.
+* Either add more worker nodes or resize existing worker nodes according to the install https://kb.vshn.ch/oc4/index.html[instructions for your cloud]
+
+=== icon:wrench[] Tune
+
+If this alert is non actionable, noisy, or was raised too late you might want to tune it.
+
+Through the component parameters you have the option modify the alert threshold, change for how long it needs to be firing until you are alerted, or disable it outright.
+In the example below will adapt the rule to only alert after four hours and change the threshold to 128 GB.
+
+[source,yaml]
+----
+capacityAlerts:
+  groups:
+    MemoryCapacity:
+      rules:
+        ClusterMemoryUsageHigh:
+          enabled: true
+          for: 4h
+          expr:
+            threshold: '128*1024*1024*1024' <1>
+----
+<1> The threshold can be an arbitrary promql expression
+
+== Alert Rule: SYN_ExpectClusterMemoryUsageHigh [[SYN_ExpectClusterMemoryUsageHigh]]
+
+=== icon:glasses[] Overview
+
+This alert means that we expect the total Memory utilization over all worker nodes might soon be high.
+By default this alert will fire if we expect the amount of unused memory to be less than the memory capacity of the largest worker node in three days.
+
+This means if you receive this alert the cluster might soon not be able to keep all workloads running in case of a worker node failure.
+After verifying the alert you should consider adding more memory capacity in the next days.
+
+=== icon:search[] Investigate
+
+* Look at the source of this alert in Prometheus
+** Does the prediction look realistic?
+** Compare it to the graph without the `predict_linear`
+** If there is any doubt in the prediction, monitor this graph for the next hours or days
+* Check the actual memory usage on each worker node
++
+[source,shell]
+----
+kubectl top nodes
+----
++
+If the number is widely different than the prediction, the alert is probably not actionable.
+* Check if there is a sudden increase in memory usage that indicate that this might be temporary or caused by a misbehaving workload.
+* Add one or more worker nodes or resize existing worker nodes according to the install https://kb.vshn.ch/oc4/index.html[instructions for your cloud]
+
+
+=== icon:wrench[] Tune
+
+If this alert isn't actionable, noisy, or was raised too late you might want to tune it.
+
+Through the component parameters you have the option tune the alert rule.
+You can modify the threshold, change for how long it needs to be firing until you are alerted, how far into the future to predict, or disable it outright.
+
+In the example below will adapt the rule so that it will alert if we expect that all memory will be utilized in 5 days, but only if it fired for 12h.
+
+[source,yaml]
+----
+capacityAlerts:
+  groups:
+    MemoryCapacity:
+      rules:
+        ExpectClusterMemoryUsageHigh:
+          enabled: true
+          for: 12h
+          expr:
+            threshold: '0' <1>
+            predict: '5*24*60*60' <2>
+----
+<1> The threshold can be an arbitrary promql expression
+<2> How far into the future to predict in seconds
+

--- a/docs/modules/ROOT/pages/runbooks/podcapacity.adoc
+++ b/docs/modules/ROOT/pages/runbooks/podcapacity.adoc
@@ -1,0 +1,112 @@
+= Alert Group: syn-PodCapacity
+
+An OpenShift cluster can handle a limited number of pods per node.
+If you try to run more pods than this limit, OpenShift won't be able to schedule these pods.
+
+We provide two rules to notice if a cluster is hitting the limit of runnable pods.
+
+== Alert Rule: SYN_TooManyPods [[SYN_TooManyPods]]
+
+=== icon:glasses[] Overview
+
+This alert means that the cluster only has capacity for few additional pods.
+By default this threshold is the pod limit per node.
+
+This means if you receive this alert the cluster will likely won't be able to keep all workloads running in case of a worker node failure.
+After verifying the alert you should add worker nodes as soon as possible.
+
+=== icon:search[] Investigate
+
+* Verify the alert
+** Check the per worker node pod limit of your cluster
++
+[source,shell]
+----
+kubectl get KubeletConfig -o yaml
+----
+** Check the number of pods on each worker node
++
+[source,shell]
+----
+kubectl describe node -lnode-role.kubernetes.io/app | grep -E "(^Name:|^Non-terminated)"
+----
+** Verify that the reported capacity is correct.
+If not there might be a bug in the alert rule.
+Please disable this alert and open an issue for this component.
+* Look at running pods for any large number of suspicious pods
+* Add one or more worker nodes according to the install https://kb.vshn.ch/oc4/index.html[instructions for your cloud]
+
+=== icon:wrench[] Tune
+
+If this alert isn't actionable, noisy, or was raised too late you might want to tune it.
+
+Through the component parameters you have the option modify the alert threshold, change for how long it needs to be firing until you are alerted, or disable it outright.
+In the example below will adapt the rule to only alert after two hours, but increase the threshold to 1000 pods.
+
+[source,yaml]
+----
+capacityAlerts:
+  enabled: false
+  groups:
+    PodCapacity:
+      rules:
+        TooManyPods:
+          enabled: true
+          for: 2h
+          expr:
+            threshold: '1000' <1>
+----
+<1> The threshold can be an arbitrary promql expression
+
+== Alert Rule: SYN_ExpectTooManyPods [[SYN_ExpectTooManyPods]]
+
+=== icon:glasses[] Overview
+
+This alert means that we expect that the cluster will soon only have capacity for few additional pods.
+By default we expect the cluster to not have enough capacity to handle a node failure in three days.
+After verifying the alert you should plan to add worker nodes in the next days.
+
+=== icon:search[] Investigate
+
+* Look at the source of this alert in Prometheus
+** Does the prediction look realistic?
+** Compare it to the graph without the `predict_linear`
+** If there is any doubt in the prediction, monitor this graph for the next hours or days
+* Check the number of actually running pods on each worker node
++
+[source,shell]
+----
+kubectl describe node -lnode-role.kubernetes.io/app | grep -E "(^Name:|^Non-terminated)"
+----
+If the number is widely different than the prediction, the alert is probably not actionable.
+* Look at running pods for any large number of suspicious pods
+* Add one or more worker nodes according to the install https://kb.vshn.ch/oc4/index.html[instructions for your cloud]
+
+
+=== icon:wrench[] Tune
+
+If this alert isn't actionable, noisy, or was raised too late you might want to tune it.
+
+Through the component parameters you have the option tune the alert rule.
+You can modify the threshold, change for how long it needs to be firing until you are alerted, how far into the future to predict, or disable it outright.
+
+
+In the example below will adapt the rule so that it will alert if we expect to not be able to schedule any more pods in 5 days, but only if it fired for 12h.
+
+[source,yaml]
+----
+capacityAlerts:
+  enabled: false
+  groups:
+    PodCapacity:
+      rules:
+        ExpectTooManyPods:
+          enabled: true
+          for: 12h
+          expr:
+            threshold: '0' <1>
+            predict: '5*24*60*60' <2>
+----
+<1> The threshold can be an arbitrary promql expression
+<2> How far into the future to predict in seconds
+

--- a/docs/modules/ROOT/pages/runbooks/podcapacity.adoc
+++ b/docs/modules/ROOT/pages/runbooks/podcapacity.adoc
@@ -3,17 +3,17 @@
 An OpenShift cluster can handle a limited number of pods per node.
 If you try to run more pods than this limit, OpenShift won't be able to schedule these pods.
 
-We provide two rules to notice if a cluster is hitting the limit of runnable pods.
+We provide two rules to notice if a cluster is hitting the limit of schedulable pods.
 
 == Alert Rule: SYN_TooManyPods [[SYN_TooManyPods]]
 
 === icon:glasses[] Overview
 
-This alert means that the cluster only has capacity for few additional pods.
-By default this threshold is the pod limit per node.
+This alert indicates that the cluster only has capacity for few additional pods.
+By default, this threshold is the pod limit per node.
 
-This means if you receive this alert the cluster will likely won't be able to keep all workloads running in case of a worker node failure.
-After verifying the alert you should add worker nodes as soon as possible.
+If you receive this alert, it's likely that the cluster won't be able to keep all workloads running in case of a worker node failure.
+After verifying that the amount of running pods in the cluster is close to the cluster's pod capacity, you should add worker nodes as soon as possible.
 
 === icon:search[] Investigate
 
@@ -31,8 +31,8 @@ kubectl get KubeletConfig -o yaml
 kubectl describe node -lnode-role.kubernetes.io/app | grep -E "(^Name:|^Non-terminated)"
 ----
 ** Verify that the reported capacity is correct.
-If not there might be a bug in the alert rule.
-Please disable this alert and open an issue for this component.
+If there's a discrepancy between the alert, and the actual number of running pods reported by Kubernetes, there might be a bug in the alert rule.
+If that's the case, please disable this alert and open an issue for this component.
 * Look at running pods for any large number of suspicious pods
 * Add one or more worker nodes according to the install https://kb.vshn.ch/oc4/index.html[instructions for your cloud]
 
@@ -62,9 +62,9 @@ capacityAlerts:
 
 === icon:glasses[] Overview
 
-This alert means that we expect that the cluster will soon only have capacity for few additional pods.
-By default we expect the cluster to not have enough capacity to handle a node failure in three days.
-After verifying the alert you should plan to add worker nodes in the next days.
+This alert indicates that we expect that the cluster will soon only have capacity for few additional pods.
+By default, we raise the alert if we expect the cluster to not have enough capacity to handle a node failure in three days.
+After verifying that the cluster's the pod count is growing, you should plan to add worker nodes in the next days.
 
 === icon:search[] Investigate
 

--- a/docs/modules/ROOT/pages/runbooks/resourcerequests.adoc
+++ b/docs/modules/ROOT/pages/runbooks/resourcerequests.adoc
@@ -7,10 +7,10 @@ If a cluster has too many requested resources it might not be able to schedule a
 
 === icon:glasses[] Overview
 
-This alert means that the total sum of memory requests of user workload is close to the capacity of the cluster.
-By default it will fire if the amount of unrequested memory is less than the capacity of the largest worker node.
+This alert indicates that the total sum of memory requests of user workload is close to the capacity of the cluster.
+By default, it will fire if the amount of unrequested memory is less than the capacity of the largest worker node.
 
-This means if you receive this alert the cluster likely won’t be able to keep all workloads running in case of a worker node failure.
+If you receive this alert, it's likely that the cluster won’t be able to reschedule all workloads in case of a worker node failure.
 After verifying the alert you should add more memory capacity as soon as possible.
 
 === icon:search[] Investigate
@@ -23,14 +23,14 @@ After verifying the alert you should add more memory capacity as soon as possibl
 kubectl describe node -lnode-role.kubernetes.io/app | grep "Allocated resources" -A 8
 ----
 +
-If not there might be a bug in the alert rule.
-Please disable this alert and open an issue for this component.
+If the allocated resources reported by Kubernetes don't indicate high memory reservation on the nodes, there might be a bug in the alert rule.
+If that's the case, please disable this alert and open an issue for this component.
 ** Check if there is a sudden increase in resource requests that indicate that this might be temporary.
 * Either add more worker nodes or resize existing worker nodes according to the install https://kb.vshn.ch/oc4/index.html[instructions for your cloud]
 
 === icon:wrench[] Tune
 
-If this alert is non actionable, noisy, or was raised too late you might want to tune it.
+If this alert isn't actionable, noisy, or was raised too late you might want to tune it.
 
 Through the component parameters you have the option modify the alert threshold, change for how long it needs to be firing until you are alerted, or disable it outright.
 In the example below will adapt the rule to only alert after two hours and change the threshold to 128 GB.
@@ -53,11 +53,11 @@ capacityAlerts:
 
 === icon:glasses[] Overview
 
-This alert means that we expect the total sum of memory requests of user workload to soon be close to the capacity of the cluster.
-By default it will fire if the predicted amount of unrequested memory in 3 days is less than the capacity of the largest worker node.
+This alert indicates that we expect the total sum of memory requests of user workload to soon be close to the capacity of the cluster.
+By default, it will fire if the predicted amount of unrequested memory in three days is less than the capacity of the largest worker node.
 
-This means if you receive this alert the cluster may soon not be able to keep all workloads running in case of a worker node failure.
-After verifying the alert you should add more memory capacity in the next days.
+If you receive this alert, the cluster may soon not be able to reschedule all workloads in case of a worker node failure.
+After verifying that the cluster's memory reservations are growing, you should add more memory capacity in the next days.
 
 === icon:search[] Investigate
 
@@ -108,11 +108,11 @@ capacityAlerts:
 
 === icon:glasses[] Overview
 
-This alert means that the total sum of CPU requests of user workload is close to the capacity of the cluster.
-By default it will fire if the amount of unrequested CPU cores is less than the core count of the largest worker node.
+This alert indicates that the total sum of CPU requests of user workloads is close to the capacity of the cluster.
+By default, it will fire if the amount of unrequested CPU cores is less than the core count of the largest worker node.
 
-This means if you receive this alert the cluster likely won’t be able to keep all workloads running in case of a worker node failure.
-After verifying the alert you should add more CPU capacity as soon as possible.
+If you receive this alert, it's likely that the cluster won’t be able to reschedule all workloads in case of a worker node failure.
+After verifying that the cluster's CPU reservation is high, you should add more CPU capacity as soon as possible.
 
 === icon:search[] Investigate
 
@@ -124,14 +124,14 @@ After verifying the alert you should add more CPU capacity as soon as possible.
 kubectl describe node -lnode-role.kubernetes.io/app | grep "Allocated resources" -A 8
 ----
 +
-If not there might be a bug in the alert rule.
-Please disable this alert and open an issue for this component.
+If the allocated resources reported by Kubernetes don't indicate high CPU reservation on the nodes, there might be a bug in the alert rule.
+If that's the case, please disable this alert and open an issue for this component.
 ** Check if there is a sudden increase in resource requests that indicate that this might be temporary.
 * Either add more worker nodes or resize existing worker nodes according to the install https://kb.vshn.ch/oc4/index.html[instructions for your cloud]
 
 === icon:wrench[] Tune
 
-If this alert is non actionable, noisy, or was raised too late you might want to tune it.
+If this alert isn't actionable, noisy, or was raised too late you might want to tune it.
 
 Through the component parameters you have the option modify the alert threshold, change for how long it needs to be firing until you are alerted, or disable it outright.
 In the example below will adapt the rule to only alert after two hours and change the threshold to 4 cores.
@@ -154,11 +154,11 @@ capacityAlerts:
 
 === icon:glasses[] Overview
 
-This alert means that we expect the total sum of CPI requests of user workload to soon be close to the capacity of the cluster.
-By default it will fire if the predicted number of unrequested CPU cores in 3 days is less than the number of cores of the largest worker node.
+This alert indicates that we expect the total sum of CPU requests of user workloads to soon be close to the capacity of the cluster.
+By default, it will fire if the predicted number of unrequested CPU cores in three days is less than the number of cores of the largest worker node.
 
-This means if you receive this alert the cluster may soon not be able to keep all workloads running in case of a worker node failure.
-After verifying the alert you should add more CPU capacity in the next days.
+If you receive this alert, the cluster may soon not be able to reschedule all workloads in case of a worker node failure.
+After verifying that the cluster's CPU reservation is growing, you should add more CPU capacity in the next days.
 
 === icon:search[] Investigate
 

--- a/docs/modules/ROOT/pages/runbooks/resourcerequests.adoc
+++ b/docs/modules/ROOT/pages/runbooks/resourcerequests.adoc
@@ -1,0 +1,205 @@
+= Alert Group: syn-ResourceRequests
+
+We provide four rules to notice if a cluster is hitting the limit of requested resources.
+If a cluster has too many requested resources it might not be able to schedule all workloads.
+
+== Alert Rule: SYN_TooMuchMemoryRequested [[SYN_TooMuchMemoryRequested]]
+
+=== icon:glasses[] Overview
+
+This alert means that the total sum of memory requests of user workload is close to the capacity of the cluster.
+By default it will fire if the amount of unrequested memory is less than the capacity of the largest worker node.
+
+This means if you receive this alert the cluster likely won’t be able to keep all workloads running in case of a worker node failure.
+After verifying the alert you should add more memory capacity as soon as possible.
+
+=== icon:search[] Investigate
+
+* Verify the alert
+** Verify that the reported capacity is correct.
++
+[source,shell]
+----
+kubectl describe node -lnode-role.kubernetes.io/app | grep "Allocated resources" -A 8
+----
++
+If not there might be a bug in the alert rule.
+Please disable this alert and open an issue for this component.
+** Check if there is a sudden increase in resource requests that indicate that this might be temporary.
+* Either add more worker nodes or resize existing worker nodes according to the install https://kb.vshn.ch/oc4/index.html[instructions for your cloud]
+
+=== icon:wrench[] Tune
+
+If this alert is non actionable, noisy, or was raised too late you might want to tune it.
+
+Through the component parameters you have the option modify the alert threshold, change for how long it needs to be firing until you are alerted, or disable it outright.
+In the example below will adapt the rule to only alert after two hours and change the threshold to 128 GB.
+
+[source,yaml]
+----
+capacityAlerts:
+  groups:
+    ResourceRequests:
+      rules:
+        TooMuchMemoryRequested:
+          enabled: true
+          for: 2h
+          expr:
+            threshold: '128*1024*1024*1024' <1>
+----
+<1> The threshold can be an arbitrary promql expression
+
+== Alert Rule: SYN_ExpectTooMuchMemoryRequested [[SYN_ExpectTooMuchMemoryRequested]]
+
+=== icon:glasses[] Overview
+
+This alert means that we expect the total sum of memory requests of user workload to soon be close to the capacity of the cluster.
+By default it will fire if the predicted amount of unrequested memory in 3 days is less than the capacity of the largest worker node.
+
+This means if you receive this alert the cluster may soon not be able to keep all workloads running in case of a worker node failure.
+After verifying the alert you should add more memory capacity in the next days.
+
+=== icon:search[] Investigate
+
+* Look at the source of this alert in Prometheus
+** Does the prediction look realistic?
+** Compare it to the graph without the `predict_linear`
+** If there is any doubt in the prediction, monitor this graph for the next hours or days
+* Check the actual resource requests on each worker node
++
+[source,shell]
+----
+kubectl describe node -lnode-role.kubernetes.io/app | grep "Allocated resources" -A 8
+----
++
+If the number is widely different than the prediction, the alert is probably not actionable.
+* Check if there is a sudden increase in resource requests that indicate that this might be temporary.
+* Add one or more worker nodes according to the install https://kb.vshn.ch/oc4/index.html[instructions for your cloud]
+
+
+=== icon:wrench[] Tune
+
+If this alert isn't actionable, noisy, or was raised too late you might want to tune it.
+
+Through the component parameters you have the option tune the alert rule.
+You can modify the threshold, change for how long it needs to be firing until you are alerted, how far into the future to predict, or disable it outright.
+
+In the example below will adapt the rule so that it will alert if we expect that all available memory will be requested in 5 days, but only if it fired for 12h.
+
+[source,yaml]
+----
+capacityAlerts:
+  groups:
+    ResourceRequests:
+      rules:
+        ExpectTooMuchMemoryRequested:
+          enabled: true
+          for: 12h
+          expr:
+            threshold: '0' <1>
+            predict: '5*24*60*60' <2>
+
+
+----
+<1> The threshold can be an arbitrary promql expression
+<2> How far into the future to predict in seconds
+
+== Alert Rule: SYN_TooMuchCPURequested [[SYN_TooMuchCPURequested]]
+
+=== icon:glasses[] Overview
+
+This alert means that the total sum of CPU requests of user workload is close to the capacity of the cluster.
+By default it will fire if the amount of unrequested CPU cores is less than the core count of the largest worker node.
+
+This means if you receive this alert the cluster likely won’t be able to keep all workloads running in case of a worker node failure.
+After verifying the alert you should add more CPU capacity as soon as possible.
+
+=== icon:search[] Investigate
+
+* Verify the alert
+** Verify that the reported capacity is correct.
++
+[source,shell]
+----
+kubectl describe node -lnode-role.kubernetes.io/app | grep "Allocated resources" -A 8
+----
++
+If not there might be a bug in the alert rule.
+Please disable this alert and open an issue for this component.
+** Check if there is a sudden increase in resource requests that indicate that this might be temporary.
+* Either add more worker nodes or resize existing worker nodes according to the install https://kb.vshn.ch/oc4/index.html[instructions for your cloud]
+
+=== icon:wrench[] Tune
+
+If this alert is non actionable, noisy, or was raised too late you might want to tune it.
+
+Through the component parameters you have the option modify the alert threshold, change for how long it needs to be firing until you are alerted, or disable it outright.
+In the example below will adapt the rule to only alert after two hours and change the threshold to 4 cores.
+
+[source,yaml]
+----
+capacityAlerts:
+  groups:
+    ResourceRequests:
+      rules:
+        TooMuchCPURequested:
+          enabled: true
+          for: 2h
+          expr:
+            threshold: '4' <1>
+----
+<1> The threshold can be an arbitrary promql expression
+
+== Alert Rule: SYN_ExpectTooMuchCPURequested [[SYN_ExpectTooMuchCPURequested]]
+
+=== icon:glasses[] Overview
+
+This alert means that we expect the total sum of CPI requests of user workload to soon be close to the capacity of the cluster.
+By default it will fire if the predicted number of unrequested CPU cores in 3 days is less than the number of cores of the largest worker node.
+
+This means if you receive this alert the cluster may soon not be able to keep all workloads running in case of a worker node failure.
+After verifying the alert you should add more CPU capacity in the next days.
+
+=== icon:search[] Investigate
+
+* Look at the source of this alert in Prometheus
+** Does the prediction look realistic?
+** Compare it to the graph without the `predict_linear`
+** If there is any doubt in the prediction, monitor this graph for the next hours or days
+* Check the actual resource requests on each worker node
++
+[source,shell]
+----
+kubectl describe node -lnode-role.kubernetes.io/app | grep "Allocated resources" -A 8
+----
++
+If the number is widely different than the prediction, the alert is probably not actionable.
+* Check if there is a sudden increase in resource requests that indicate that this might be temporary.
+* Add one or more worker nodes according to the install https://kb.vshn.ch/oc4/index.html[instructions for your cloud]
+
+
+=== icon:wrench[] Tune
+
+If this alert isn't actionable, noisy, or was raised too late you might want to tune it.
+
+Through the component parameters you have the option tune the alert rule.
+You can modify the threshold, change for how long it needs to be firing until you are alerted, how far into the future to predict, or disable it outright.
+
+In the example below will adapt the rule so that it will alert if we expect that all CPU cores will be requested in 5 days, but only if it fired for 12h.
+
+[source,yaml]
+----
+capacityAlerts:
+  groups:
+    ResourceRequests:
+      rules:
+        ExpectTooMuchCPURequested:
+          enabled: true
+          for: 12h
+          expr:
+            threshold: '0' <1>
+            predict: '5*24*60*60' <2>
+----
+<1> The threshold can be an arbitrary promql expression
+<2> How far into the future to predict in seconds
+

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -5,3 +5,12 @@
 .How-Tos
 * xref:how-tos/opsgenie.adoc[OpsGenie integration]
 * xref:how-tos/migrate/v0.1-v1.x.adoc[Migration from component version v0.1.0 to v1.x]
+
+.Explanation
+* xref:explanations/resource_management.adoc[Resource Management]
+
+.Runbooks
+* xref:runbooks/podcapacity.adoc[Pod Capacity Alert]
+* xref:runbooks/resourcerequests.adoc[Resource Requests Alert]
+* xref:runbooks/memorycapacity.adoc[Memory Capacity Alert]
+* xref:runbooks/cpucapacity.adoc[CPU Capacity Alert]


### PR DESCRIPTION
This PR adds capacity planing alerts. It adds alerts for pod count as well as CPU/memory requests and actual utilization for worker nodes.

The actual alerts might need some tweaking, but should be easily done through the parameters.

This took a lot longer than anticipated and I probably went a bit overboard, but I did not want to throw in some half baked alerts.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
