### PR TITLE
Tune capacity alert prediction

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -119,7 +119,7 @@ parameters:
                 message: 'Expected to exceed the threshold of running pods in 3 days'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_ExpectTooManyPods
                 description: 'The cluster is getting close to the limit of running pods. Soon the cluster might not be able to handle a node failure and might not be able to start new pods. Consider adding new nodes.'
-              for: 1h
+              for: 3h
               labels: {}
               expr:
                 # How many more pods need to be schedulable in three days
@@ -148,7 +148,7 @@ parameters:
                 message: 'Expected to exceed the threshold of requested memory in 3 days'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_ExpectTooMuchMemoryRequested
                 description: 'The cluster is getting close to asigning all memory to running pods. Soon the cluster might not be able to handle a node failure and might not be able to start new pods. Consider adding new nodes.'
-              for: 1h
+              for: 3h
               labels: {}
               expr:
                 # How much memory needs to be available to allocate in three days (in bytes)
@@ -174,7 +174,7 @@ parameters:
                 message: 'Expected to exceed the threshold of requested CPU resources in 3 days'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_ExpectTooMuchCPURequested
                 description: 'The cluster is getting close to asigning all CPU cores to running pods. Soon the cluster might not be able to handle a node failure and might not be able to start new pods. Consider adding new nodes.'
-              for: 1h
+              for: 3h
               labels: {}
               expr:
                 # How many cpu cores need to be available to allocate in three days
@@ -203,7 +203,7 @@ parameters:
                 message: 'Cluster expected to run low on memory in 3 days'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ExpectClusterMemoryUsageHigh
                 description: 'The cluster is getting close to using all of its memory. Soon the cluster might not be able to handle a node failure or load spikes. Consider adding new nodes.'
-              for: 1h
+              for: 3h
               labels: {}
               expr:
                 # How much memory needs to be over all worker nodes in three days (in bytes)
@@ -221,7 +221,7 @@ parameters:
                 message: 'Only {{ $value }} idle cpu cores accross cluster.'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
                 description: 'The cluster is close to using up all CPU resources. The cluster might not be able to handle a node failure or load spikes. Consider adding new nodes.'
-              for: 2h
+              for: 30m
               labels: {}
               expr:
                 # How many cpu cores need to be available to allocate
@@ -233,7 +233,7 @@ parameters:
                 message: 'Cluster expected to run low on available CPU resources in 3 days'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ExpectClusterCpuUsageHigh
                 description: 'The cluster is getting close to using up all CPU resources. The cluster might soon not be able to handle a node failure or load spikes. Consider adding new nodes.'
-              for: 2h
+              for: 3h
               labels: {}
               expr:
                 # How many cpu cores need to be idle

--- a/component/capacity.libsonnet
+++ b/component/capacity.libsonnet
@@ -17,7 +17,7 @@ local alertLabels = {
   severity: 'warning',
 };
 
-local predict(indicator, range='1d', resolution='1h', predict='3*24*60*60') =
+local predict(indicator, range='1d', resolution='5m', predict='3*24*60*60') =
   'predict_linear(avg_over_time(%(indicator)s[%(range)s:%(resolution)s])[%(range)s:%(resolution)s], %(predict)s)' %
   { indicator: indicator, range: range, resolution: resolution, predict: predict };
 


### PR DESCRIPTION
* Increase time alert needs to be firing for. If a 3 day prediction
  does not hold for more than 3h it's not relevant.
* Drastically higher resolution for prediction. The low resolution of 1h
  coupled with the firing `for` threshold of `1h` probably lead to a
  weird flapping alert.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
