### PR TITLE
Add option to multiply the default thresholds for capacity alerts

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -107,23 +107,27 @@ parameters:
               annotations:
                 message: 'Only {{ $value }} more pods can be started.'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
-                description: 'The cluster is close to the limit of running pods. The cluster might not be able to handle a node failure and might not be able to start new pods. Consider adding new nodes.'
+                description: 'The cluster is close to the limit of running pods. The cluster might not be able to handle node failures and might not be able to start new pods. Consider adding new nodes.'
               for: 30m
               labels: {}
               expr:
                 # How many more pods need to be schedulable
                 threshold: 'max(kube_node_status_capacity{resource="pods"} * on(node) group_left kube_node_role{role="app"})'
+                # Multiply the threshold by this factor
+                factor: 1
             ExpectTooManyPods:
               enabled: true
               annotations:
                 message: 'Expected to exceed the threshold of running pods in 3 days'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_ExpectTooManyPods
-                description: 'The cluster is getting close to the limit of running pods. Soon the cluster might not be able to handle a node failure and might not be able to start new pods. Consider adding new nodes.'
+                description: 'The cluster is getting close to the limit of running pods. Soon the cluster might not be able to handle node failures and might not be able to start new pods. Consider adding new nodes.'
               for: 3h
               labels: {}
               expr:
                 # How many more pods need to be schedulable in three days
                 threshold: 'max(kube_node_status_capacity{resource="pods"} * on(node) group_left kube_node_role{role="app"})'
+                # Multiply the threshold by this factor
+                factor: 1
                 # How much of the past to consider for the prediction
                 range: '1d'
                 # How far into the future to predict (in seconds)
@@ -136,23 +140,27 @@ parameters:
               annotations:
                 message: 'Only {{ $value }} memory left for new pods.'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
-                description: 'The cluster is close to asigning all memory to running pods. The cluster might not be able to handle a node failure and might not be able to start new pods. Consider adding new nodes.'
+                description: 'The cluster is close to asigning all memory to running pods. The cluster might not be able to handle node failures and might not be able to start new pods. Consider adding new nodes.'
               for: 30m
               labels: {}
               expr:
                 # How much memory needs to be available to allocate (in bytes)
                 threshold: 'max(kube_node_status_allocatable{resource="memory"} * on(node) group_left kube_node_role{role="app"})'
+                # Multiply the threshold by this factor
+                factor: 1
             ExpectTooMuchMemoryRequested:
               enabled: true
               annotations:
                 message: 'Expected to exceed the threshold of requested memory in 3 days'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_ExpectTooMuchMemoryRequested
-                description: 'The cluster is getting close to asigning all memory to running pods. Soon the cluster might not be able to handle a node failure and might not be able to start new pods. Consider adding new nodes.'
+                description: 'The cluster is getting close to asigning all memory to running pods. Soon the cluster might not be able to handle node failures and might not be able to start new pods. Consider adding new nodes.'
               for: 3h
               labels: {}
               expr:
                 # How much memory needs to be available to allocate in three days (in bytes)
                 threshold: 'max(kube_node_status_allocatable{resource="memory"} * on(node) group_left kube_node_role{role="app"})'
+                # Multiply the threshold by this factor
+                factor: 1
                 # How much of the past to consider for the prediction
                 range: '1d'
                 # How far into the future to predict (in seconds)
@@ -162,23 +170,27 @@ parameters:
               annotations:
                 message: 'Only {{ $value }} cpu cores left for new pods.'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
-                description: 'The cluster is close to asigning all CPU resources to running pods. The cluster might not be able to handle a node failure and might soon not be able to start new pods. Consider adding new nodes.'
+                description: 'The cluster is close to asigning all CPU resources to running pods. The cluster might not be able to handle node failures and might soon not be able to start new pods. Consider adding new nodes.'
               for: 30m
               labels: {}
               expr:
                 # How many cpu cores need to be available to allocate
                 threshold: 'max(kube_node_status_allocatable{resource="cpu"} * on(node) group_left kube_node_role{role="app"})'
+                # Multiply the threshold by this factor
+                factor: 1
             ExpectTooMuchCPURequested:
               enabled: true
               annotations:
                 message: 'Expected to exceed the threshold of requested CPU resources in 3 days'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_ExpectTooMuchCPURequested
-                description: 'The cluster is getting close to asigning all CPU cores to running pods. Soon the cluster might not be able to handle a node failure and might not be able to start new pods. Consider adding new nodes.'
+                description: 'The cluster is getting close to asigning all CPU cores to running pods. Soon the cluster might not be able to handle node failures and might not be able to start new pods. Consider adding new nodes.'
               for: 3h
               labels: {}
               expr:
                 # How many cpu cores need to be available to allocate in three days
                 threshold: 'max(kube_node_status_allocatable{resource="cpu"} * on(node) group_left kube_node_role{role="app"})'
+                # Multiply the threshold by this factor
+                factor: 1
                 # How much of the past to consider for the prediction
                 range: '1d'
                 # How far into the future to predict (in seconds)
@@ -191,23 +203,27 @@ parameters:
               annotations:
                 message: 'Only {{ $value }} free memory on Worker Nodes.'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
-                description: 'The cluster is close to using all of its memory. The cluster might not be able to handle a node failure or load spikes. Consider adding new nodes.'
+                description: 'The cluster is close to using all of its memory. The cluster might not be able to handle node failures or load spikes. Consider adding new nodes.'
               for: 30m
               labels: {}
               expr:
                 # How much memory needs to be free over all worker nodes (in bytes)
                 threshold: 'max(kube_node_status_capacity{resource="memory"} * on(node) group_left kube_node_role{role="app"})'
+                # Multiply the threshold by this factor
+                factor: 1
             ExpectClusterLowOnMemory:
               enabled: true
               annotations:
                 message: 'Cluster expected to run low on memory in 3 days'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ExpectClusterMemoryUsageHigh
-                description: 'The cluster is getting close to using all of its memory. Soon the cluster might not be able to handle a node failure or load spikes. Consider adding new nodes.'
+                description: 'The cluster is getting close to using all of its memory. Soon the cluster might not be able to handle node failures or load spikes. Consider adding new nodes.'
               for: 3h
               labels: {}
               expr:
                 # How much memory needs to be over all worker nodes in three days (in bytes)
                 threshold: 'max(kube_node_status_capacity{resource="memory"} * on(node) group_left kube_node_role{role="app"})'
+                # Multiply the threshold by this factor
+                factor: 1
                 # How much of the past to consider for the prediction
                 range: '1d'
                 # How far into the future to predict (in seconds)
@@ -220,24 +236,28 @@ parameters:
               annotations:
                 message: 'Only {{ $value }} idle cpu cores accross cluster.'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
-                description: 'The cluster is close to using up all CPU resources. The cluster might not be able to handle a node failure or load spikes. Consider adding new nodes.'
+                description: 'The cluster is close to using up all CPU resources. The cluster might not be able to handle node failures or load spikes. Consider adding new nodes.'
               for: 30m
               labels: {}
               expr:
                 # How many cpu cores need to be available to allocate
                 threshold: 'max(kube_node_status_capacity{resource="cpu"} * on(node) group_left kube_node_role{role="app"})'
+                # Multiply the threshold by this factor
+                factor: 1
 
             ExpectClusterCpuUsageHigh:
               enabled: true
               annotations:
                 message: 'Cluster expected to run low on available CPU resources in 3 days'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ExpectClusterCpuUsageHigh
-                description: 'The cluster is getting close to using up all CPU resources. The cluster might soon not be able to handle a node failure or load spikes. Consider adding new nodes.'
+                description: 'The cluster is getting close to using up all CPU resources. The cluster might soon not be able to handle node failures or load spikes. Consider adding new nodes.'
               for: 3h
               labels: {}
               expr:
                 # How many cpu cores need to be idle
                 threshold: 'max(kube_node_status_capacity{resource="cpu"} * on(node) group_left kube_node_role{role="app"})'
+                # Multiply the threshold by this factor
+                factor: 1
                 # How much of the past to consider for the prediction
                 range: '1d'
                 # How far into the future to predict (in seconds)

--- a/component/capacity.libsonnet
+++ b/component/capacity.libsonnet
@@ -43,19 +43,19 @@ local podCapacity = resourceCapacity('pods');
 local podCount = 'sum(%s)' % filterWorkerNodes('kubelet_running_pods');
 
 local exprMap = {
-  TooManyPods: function(arg) '%s - %s < %s' % [ podCapacity, podCount, arg.threshold ],
-  ExpectTooManyPods: function(arg) '%s - %s < %s' % [ podCapacity, predict(podCount, range=arg.range, predict=arg.predict), arg.threshold ],
+  TooManyPods: function(arg) '%s - %s < %d * %s' % [ podCapacity, podCount, arg.factor, arg.threshold ],
+  ExpectTooManyPods: function(arg) '%s - %s < %d * %s' % [ podCapacity, predict(podCount, range=arg.range, predict=arg.predict), arg.factor, arg.threshold ],
 
-  TooMuchMemoryRequested: function(arg) '%s - %s < %s' % [ memoryAllocatable, memoryRequests, arg.threshold ],
-  ExpectTooMuchMemoryRequested: function(arg) '%s - %s < %s' % [ memoryAllocatable, predict(memoryRequests, range=arg.range, predict=arg.predict), arg.threshold ],
-  TooMuchCPURequested: function(arg) '%s - %s < %s' % [ cpuAllocatable, cpuRequests, arg.threshold ],
-  ExpectTooMuchCPURequested: function(arg) '%s - %s < %s' % [ cpuAllocatable, predict(cpuRequests, range=arg.range, predict=arg.predict), arg.threshold ],
+  TooMuchMemoryRequested: function(arg) '%s - %s < %d * %s' % [ memoryAllocatable, memoryRequests, arg.factor, arg.threshold ],
+  ExpectTooMuchMemoryRequested: function(arg) '%s - %s < %d * %s' % [ memoryAllocatable, predict(memoryRequests, range=arg.range, predict=arg.predict), arg.factor, arg.threshold ],
+  TooMuchCPURequested: function(arg) '%s - %s < %d * %s' % [ cpuAllocatable, cpuRequests, arg.factor, arg.threshold ],
+  ExpectTooMuchCPURequested: function(arg) '%s - %s < %d * %s' % [ cpuAllocatable, predict(cpuRequests, range=arg.range, predict=arg.predict), arg.factor, arg.threshold ],
 
-  ClusterLowOnMemory: function(arg) '%s < %s' % [ memoryFree, arg.threshold ],
-  ExpectClusterLowOnMemory: function(arg) '%s < %s' % [ predict(memoryFree, range=arg.range, predict=arg.predict), arg.threshold ],
+  ClusterLowOnMemory: function(arg) '%s < %d * %s' % [ memoryFree, arg.factor, arg.threshold ],
+  ExpectClusterLowOnMemory: function(arg) '%s < %d * %s' % [ predict(memoryFree, range=arg.range, predict=arg.predict), arg.factor, arg.threshold ],
 
-  ClusterCpuUsageHigh: function(arg) '%s < %s' % [ cpuIdle, arg.threshold ],
-  ExpectClusterCpuUsageHigh: function(arg) '%s < %s' % [ predict(cpuIdle, range=arg.range, predict=arg.predict), arg.threshold ],
+  ClusterCpuUsageHigh: function(arg) '%s < %d * %s' % [ cpuIdle, arg.factor, arg.threshold ],
+  ExpectClusterCpuUsageHigh: function(arg) '%s < %d * %s' % [ predict(cpuIdle, range=arg.range, predict=arg.predict), arg.factor, arg.threshold ],
 };
 
 {


### PR DESCRIPTION
The default thresholds are always the value of the largest worker node. It is helpful to alert if we reach the threshold of multiple nodes without having to replace the complete threshold

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
