### PR TITLE
Handle non integer factors for capacity alerts

### DIFF
--- a/component/capacity.libsonnet
+++ b/component/capacity.libsonnet
@@ -43,19 +43,19 @@ local podCapacity = resourceCapacity('pods');
 local podCount = 'sum(%s)' % filterWorkerNodes('kubelet_running_pods');
 
 local exprMap = {
-  TooManyPods: function(arg) '%s - %s < %d * %s' % [ podCapacity, podCount, arg.factor, arg.threshold ],
-  ExpectTooManyPods: function(arg) '%s - %s < %d * %s' % [ podCapacity, predict(podCount, range=arg.range, predict=arg.predict), arg.factor, arg.threshold ],
+  TooManyPods: function(arg) '%s - %s < %f * %s' % [ podCapacity, podCount, arg.factor, arg.threshold ],
+  ExpectTooManyPods: function(arg) '%s - %s < %f * %s' % [ podCapacity, predict(podCount, range=arg.range, predict=arg.predict), arg.factor, arg.threshold ],
 
-  TooMuchMemoryRequested: function(arg) '%s - %s < %d * %s' % [ memoryAllocatable, memoryRequests, arg.factor, arg.threshold ],
-  ExpectTooMuchMemoryRequested: function(arg) '%s - %s < %d * %s' % [ memoryAllocatable, predict(memoryRequests, range=arg.range, predict=arg.predict), arg.factor, arg.threshold ],
-  TooMuchCPURequested: function(arg) '%s - %s < %d * %s' % [ cpuAllocatable, cpuRequests, arg.factor, arg.threshold ],
-  ExpectTooMuchCPURequested: function(arg) '%s - %s < %d * %s' % [ cpuAllocatable, predict(cpuRequests, range=arg.range, predict=arg.predict), arg.factor, arg.threshold ],
+  TooMuchMemoryRequested: function(arg) '%s - %s < %f * %s' % [ memoryAllocatable, memoryRequests, arg.factor, arg.threshold ],
+  ExpectTooMuchMemoryRequested: function(arg) '%s - %s < %f * %s' % [ memoryAllocatable, predict(memoryRequests, range=arg.range, predict=arg.predict), arg.factor, arg.threshold ],
+  TooMuchCPURequested: function(arg) '%s - %s < %f * %s' % [ cpuAllocatable, cpuRequests, arg.factor, arg.threshold ],
+  ExpectTooMuchCPURequested: function(arg) '%s - %s < %f * %s' % [ cpuAllocatable, predict(cpuRequests, range=arg.range, predict=arg.predict), arg.factor, arg.threshold ],
 
-  ClusterLowOnMemory: function(arg) '%s < %d * %s' % [ memoryFree, arg.factor, arg.threshold ],
-  ExpectClusterLowOnMemory: function(arg) '%s < %d * %s' % [ predict(memoryFree, range=arg.range, predict=arg.predict), arg.factor, arg.threshold ],
+  ClusterLowOnMemory: function(arg) '%s < %f * %s' % [ memoryFree, arg.factor, arg.threshold ],
+  ExpectClusterLowOnMemory: function(arg) '%s < %f * %s' % [ predict(memoryFree, range=arg.range, predict=arg.predict), arg.factor, arg.threshold ],
 
-  ClusterCpuUsageHigh: function(arg) '%s < %d * %s' % [ cpuIdle, arg.factor, arg.threshold ],
-  ExpectClusterCpuUsageHigh: function(arg) '%s < %d * %s' % [ predict(cpuIdle, range=arg.range, predict=arg.predict), arg.factor, arg.threshold ],
+  ClusterCpuUsageHigh: function(arg) '%s < %f * %s' % [ cpuIdle, arg.factor, arg.threshold ],
+  ExpectClusterCpuUsageHigh: function(arg) '%s < %f * %s' % [ predict(cpuIdle, range=arg.range, predict=arg.predict), arg.factor, arg.threshold ],
 };
 
 {


### PR DESCRIPTION
With #85 we introduced factors for the capacity alert thresholds. These factors should be floats not integers.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
