### PR TITLE
Disable predictive capacity alerts by default

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -126,7 +126,7 @@ parameters:
                 # Multiply the threshold by this factor
                 factor: 1
             ExpectTooManyPods:
-              enabled: true
+              enabled: false
               annotations:
                 message: 'Expected to exceed the threshold of running pods in 3 days'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_ExpectTooManyPods
@@ -159,7 +159,7 @@ parameters:
                 # Multiply the threshold by this factor
                 factor: 1
             ExpectTooMuchMemoryRequested:
-              enabled: true
+              enabled: false
               annotations:
                 message: 'Expected to exceed the threshold of requested memory in 3 days'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_ExpectTooMuchMemoryRequested
@@ -189,7 +189,7 @@ parameters:
                 # Multiply the threshold by this factor
                 factor: 1
             ExpectTooMuchCPURequested:
-              enabled: true
+              enabled: false
               annotations:
                 message: 'Expected to exceed the threshold of requested CPU resources in 3 days'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_ExpectTooMuchCPURequested
@@ -222,7 +222,7 @@ parameters:
                 # Multiply the threshold by this factor
                 factor: 1
             ExpectClusterLowOnMemory:
-              enabled: true
+              enabled: false
               annotations:
                 message: 'Cluster expected to run low on memory in 3 days'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ExpectClusterMemoryUsageHigh
@@ -256,7 +256,7 @@ parameters:
                 factor: 1
 
             ExpectClusterCpuUsageHigh:
-              enabled: true
+              enabled: false
               annotations:
                 message: 'Cluster expected to run low on available CPU resources in 3 days'
                 runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ExpectClusterCpuUsageHigh

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -288,6 +288,7 @@ type:: dict
 
 This parameter allows users to enable and configure alerts for capacity management.
 The capacity alerts are disabled by default and can be enabled by setting the key `capacityAlerts.enabled` to `true`.
+Predictive alerts are disabled by default and can be enabled, as exampled by `ExpectClusterCpuUsageHigh.enabled` to `true`.
 
 The dictionary will be transformed into a `PrometheusRule` object by the component.
 


### PR DESCRIPTION
If required, these alerts can be enabled by choice on a cluster. As a baseline, the
standard non-predictive alerts are enough.

This reduces the amount of tenant data written.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
