### PR TITLE
Give prometheus permissions to auto-discover targets

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -71,6 +71,7 @@ local ns_patch =
       'alertmanager.yaml': std.manifestYamlDoc(params.alertManagerConfig),
     },
   },
+  rbac: import 'rbac.libsonnet',
   prometheus_rules: rules,
   silence: import 'silence.jsonnet',
   [if params.capacityAlerts.enabled then 'capacity_rules']: capacity.rules,

--- a/component/rbac.libsonnet
+++ b/component/rbac.libsonnet
@@ -9,7 +9,8 @@ local defaultAnnotations = {
 };
 
 /*
-* Allows discovery of services, pods, and endpoints for prometheus auto-discovery
+* Allows Prometheus auto-discovery.
+* Adds the recommended permissions from https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/rbac.md#prometheus-rbac
 */
 local discoveryRole = kube.ClusterRole('syn-prometheus-auto-discovery') {
   metadata+: {

--- a/component/rbac.libsonnet
+++ b/component/rbac.libsonnet
@@ -1,7 +1,8 @@
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
-local params = inv.parameters.control_api;
+
+local params = inv.parameters.openshift4_monitoring;
 
 local defaultAnnotations = {
   syn_component: inv.parameters._instance,
@@ -55,7 +56,7 @@ local discoveryRoleBinding = kube.ClusterRoleBinding('syn-prometheus-auto-discov
     {
       kind: 'ServiceAccount',
       name: 'prometheus-k8s',
-      namespace: 'openshift-monitoring',
+      namespace: params.namespace,
     },
   ],
 };

--- a/component/rbac.libsonnet
+++ b/component/rbac.libsonnet
@@ -30,6 +30,19 @@ local discoveryRole = kube.ClusterRole('syn-prometheus-auto-discovery') {
         'watch',
       ],
     },
+    {
+      apiGroups: [
+        'networking.k8s.io',
+      ],
+      resources: [
+        'ingresses',
+      ],
+      verbs: [
+        'get',
+        'list',
+        'watch',
+      ],
+    },
   ],
 };
 

--- a/component/rbac.libsonnet
+++ b/component/rbac.libsonnet
@@ -1,0 +1,51 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+local params = inv.parameters.control_api;
+
+local defaultAnnotations = {
+  syn_component: inv.parameters._instance,
+};
+
+/*
+* Allows discovery of services, pods, and endpoints for prometheus auto-discovery
+*/
+local discoveryRole = kube.ClusterRole('syn-prometheus-auto-discovery') {
+  metadata+: {
+    annotations+: defaultAnnotations,
+  },
+  rules: [
+    {
+      apiGroups: [
+        '',
+      ],
+      resources: [
+        'pods',
+        'services',
+        'endpoints',
+      ],
+      verbs: [
+        'get',
+        'list',
+        'watch',
+      ],
+    },
+  ],
+};
+
+local discoveryRoleBinding = kube.ClusterRoleBinding('syn-prometheus-auto-discovery') {
+  metadata+: {
+    annotations+: defaultAnnotations,
+  },
+  roleRef_: discoveryRole,
+  subjects: [
+    {
+      kind: 'ServiceAccount',
+      name: 'prometheus-k8s',
+      namespace: 'openshift-monitoring',
+    },
+  ],
+};
+
+
+[ discoveryRole, discoveryRoleBinding ]

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/rbac.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/rbac.yaml
@@ -17,6 +17,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/rbac.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    syn_component: openshift4-monitoring
+  labels:
+    name: syn-prometheus-auto-discovery
+  name: syn-prometheus-auto-discovery
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    syn_component: openshift4-monitoring
+  labels:
+    name: syn-prometheus-auto-discovery
+  name: syn-prometheus-auto-discovery
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-prometheus-auto-discovery
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/rbac.yaml
+++ b/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/rbac.yaml
@@ -17,6 +17,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/rbac.yaml
+++ b/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    syn_component: openshift4-monitoring
+  labels:
+    name: syn-prometheus-auto-discovery
+  name: syn-prometheus-auto-discovery
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    syn_component: openshift4-monitoring
+  labels:
+    name: syn-prometheus-auto-discovery
+  name: syn-prometheus-auto-discovery
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-prometheus-auto-discovery
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/rbac.yaml
+++ b/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/rbac.yaml
@@ -17,6 +17,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/rbac.yaml
+++ b/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    syn_component: openshift4-monitoring
+  labels:
+    name: syn-prometheus-auto-discovery
+  name: syn-prometheus-auto-discovery
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    syn_component: openshift4-monitoring
+  labels:
+    name: syn-prometheus-auto-discovery
+  name: syn-prometheus-auto-discovery
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-prometheus-auto-discovery
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring


### PR DESCRIPTION
RedHat fix a permission bug we were (ab-)using. We now need to explicitly give the prometheus instance permission to list all pods, services, and endpoints. See https://issues.redhat.com/browse/LOG-2286



## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
