### PR TITLE
Allow removing remote write configs by setting them to `null`

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -53,7 +53,11 @@ local ns_patch =
                 _remoteWrite+:: {},
               } + {
                 local rwd = super._remoteWrite,
-                remoteWrite+: [ rwd[name] { name: name } for name in std.objectFields(rwd) ],
+                remoteWrite+: std.filterMap(
+                  function(name) rwd[name] != null,
+                  function(name) rwd[name] { name: name },
+                  std.objectFields(rwd)
+                ),
               },
             },
           )


### PR DESCRIPTION


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
