### PR TITLE
Explicitly configure projected SA token volume for silence cronjob

### DIFF
--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -65,6 +65,9 @@ spec:
                 - mountPath: /etc/ssl/certs/serving-certs/
                   name: ca-bundle
                   readOnly: true
+                - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                  name: kube-api-access
+                  readOnly: true
                 - mountPath: /usr/local/bin/silence
                   name: scripts
                   readOnly: true
@@ -81,6 +84,13 @@ spec:
                 defaultMode: 288
                 name: serving-certs-ca-bundle
               name: ca-bundle
+            - name: kube-api-access
+              projected:
+                defaultMode: 420
+                sources:
+                  - serviceAccountToken:
+                      expirationSeconds: 3607
+                      path: token
             - configMap:
                 defaultMode: 360
                 name: silence

--- a/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -65,6 +65,9 @@ spec:
                 - mountPath: /etc/ssl/certs/serving-certs/
                   name: ca-bundle
                   readOnly: true
+                - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                  name: kube-api-access
+                  readOnly: true
                 - mountPath: /usr/local/bin/silence
                   name: scripts
                   readOnly: true
@@ -81,6 +84,13 @@ spec:
                 defaultMode: 288
                 name: serving-certs-ca-bundle
               name: ca-bundle
+            - name: kube-api-access
+              projected:
+                defaultMode: 420
+                sources:
+                  - serviceAccountToken:
+                      expirationSeconds: 3607
+                      path: token
             - configMap:
                 defaultMode: 360
                 name: silence

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -65,6 +65,9 @@ spec:
                 - mountPath: /etc/ssl/certs/serving-certs/
                   name: ca-bundle
                   readOnly: true
+                - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                  name: kube-api-access
+                  readOnly: true
                 - mountPath: /usr/local/bin/silence
                   name: scripts
                   readOnly: true
@@ -81,6 +84,13 @@ spec:
                 defaultMode: 288
                 name: serving-certs-ca-bundle
               name: ca-bundle
+            - name: kube-api-access
+              projected:
+                defaultMode: 420
+                sources:
+                  - serviceAccountToken:
+                      expirationSeconds: 3607
+                      path: token
             - configMap:
                 defaultMode: 360
                 name: silence

--- a/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -65,6 +65,9 @@ spec:
                 - mountPath: /etc/ssl/certs/serving-certs/
                   name: ca-bundle
                   readOnly: true
+                - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                  name: kube-api-access
+                  readOnly: true
                 - mountPath: /usr/local/bin/silence
                   name: scripts
                   readOnly: true
@@ -81,6 +84,13 @@ spec:
                 defaultMode: 288
                 name: serving-certs-ca-bundle
               name: ca-bundle
+            - name: kube-api-access
+              projected:
+                defaultMode: 420
+                sources:
+                  - serviceAccountToken:
+                      expirationSeconds: 3607
+                      path: token
             - configMap:
                 defaultMode: 360
                 name: silence

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -65,6 +65,9 @@ spec:
                 - mountPath: /etc/ssl/certs/serving-certs/
                   name: ca-bundle
                   readOnly: true
+                - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                  name: kube-api-access
+                  readOnly: true
                 - mountPath: /usr/local/bin/silence
                   name: scripts
                   readOnly: true
@@ -81,6 +84,13 @@ spec:
                 defaultMode: 288
                 name: serving-certs-ca-bundle
               name: ca-bundle
+            - name: kube-api-access
+              projected:
+                defaultMode: 420
+                sources:
+                  - serviceAccountToken:
+                      expirationSeconds: 3607
+                      path: token
             - configMap:
                 defaultMode: 360
                 name: silence


### PR DESCRIPTION
On fresh OpenShift 4.11 installations, the `prometheus-k8s` ServiceAccount has `automountServiceAccountToken=false` which prevents automatic creation of the projected SA token volume. On upgraded clusters, this configuration for the ServiceAccount isn't updated.

This commit updates the silence cronjob to have an explicit projected SA token volume which should resolve the issue of the cronjob failing to find the SA token on fresh 4.11 installations.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
