### PR TITLE
Aggregate `monitoring.coreos.com` objects to `cluster-reader`

### DIFF
--- a/component/aggregated-clusterroles.libsonnet
+++ b/component/aggregated-clusterroles.libsonnet
@@ -1,0 +1,25 @@
+local kube = import 'lib/kube.libjsonnet';
+
+local cluster_reader =
+  kube.ClusterRole('syn-openshift4-monitoring-cluster-reader') {
+    metadata+: {
+      labels+: {
+        'rbac.authorization.k8s.io/aggregate-to-cluster-reader': 'true',
+      },
+    },
+    rules: [
+      {
+        apiGroups: [ 'monitoring.coreos.com' ],
+        resources: [ '*' ],
+        verbs: [
+          'get',
+          'list',
+          'watch',
+        ],
+      },
+    ],
+  };
+
+[
+  cluster_reader,
+]

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -37,6 +37,7 @@ local ns_patch =
 {
   '00_namespace_labels': ns_patch,
   '01_secrets': secrets,
+  '02_aggregated_clusterroles': (import 'aggregated-clusterroles.libsonnet'),
   [if std.length(params.configs) > 0 then '10_configmap']:
     kube.ConfigMap('cluster-monitoring-config') {
       metadata+: {

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -21,3 +21,8 @@ By doing so, the monitoring can be run on only a subset of the worker nodes.
 Ensure that the target cluster does have nodes with the infra role label set.
 See the components defaults for the exact value.
 ====
+
+== Cluster-reader permissions
+
+The component deploys a `ClusterRole` which grants `get`, `list`, and `watch` permissions on all `monitoring.coreos.com` resources.
+This `ClusterRole` is configured to be aggregated to the `cluster-reader` `ClusterRole`, thus granting users which have `cluster-reader` read-only access to all `monitoring.coreos.com` resources in the cluster.

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/02_aggregated_clusterroles.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/02_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-openshift4-monitoring-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-openshift4-monitoring-cluster-reader
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/02_aggregated_clusterroles.yaml
+++ b/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/02_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-openshift4-monitoring-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-openshift4-monitoring-cluster-reader
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/02_aggregated_clusterroles.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/02_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-openshift4-monitoring-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-openshift4-monitoring-cluster-reader
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/02_aggregated_clusterroles.yaml
+++ b/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/02_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-openshift4-monitoring-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-openshift4-monitoring-cluster-reader
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/02_aggregated_clusterroles.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/02_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-openshift4-monitoring-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-openshift4-monitoring-cluster-reader
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/02_aggregated_clusterroles.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/02_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-openshift4-monitoring-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-openshift4-monitoring-cluster-reader
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
We add a custom clusterrole which is aggregated to `cluster-reader` which grants `get`, `list`, `watch` on all `monitoring.coreos.com` resources. This should allow users which have cluster-reader look at Prometheus rules, ServiceMonitors etc. without having to impersonate cluster-admin.



## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
