### PR TITLE
Provide component library with functions for alert patching and filtering

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -3,6 +3,7 @@ parameters:
     =_metadata:
       library_aliases:
         prom.libsonnet: openshift4-monitoring-prom.libsonnet
+        alert-patching.libsonnet: openshift4-monitoring-alert-patching.libsonnet
     namespace: openshift-monitoring
     # TODO: select based on reported OCP version once we have dynamic facts
     manifests_version: release-4.9

--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -8,6 +8,8 @@ local defaultAnnotations = {
   syn_component: inv.parameters._instance,
 };
 
+local alertpatching = import 'lib/alert-patching.libsonnet';
+
 local excludeESOperatorRules =
   local loggingVersion =
     local ver = std.get(
@@ -144,14 +146,7 @@ local additionalRules = {
 local filterRules = {
   spec+: {
     groups: [
-      group {
-        rules: std.filter(
-          function(rule)
-            std.objectHas(rule, 'alert') &&
-            !std.member(params.alerts.ignoreNames, rule.alert),
-          group.rules
-        ),
-      }
+      alertpatching.filterRules(group, params.alerts.ignoreNames)
       for group in super.groups
     ],
   },
@@ -201,14 +196,7 @@ local patchRules = {
       function(group)
         group {
           rules: std.map(
-            function(rule)
-              if (
-                std.objectHas(rule, 'alert') &&
-                std.objectHas(rulePatches, rule.alert)
-              ) then
-                rule + com.makeMergeable(rulePatches[rule.alert])
-              else
-                rule,
+            function(rule) alertpatching.patchRule(rule, rulePatches, false),
             group.rules
           ),
         },

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -1,6 +1,8 @@
 * xref:index.adoc[Home]
+
 .Reference
 * xref:references/parameters.adoc[Parameters]
+* xref:references/alert-patching.adoc[]
 
 .How-Tos
 * xref:how-tos/opsgenie.adoc[OpsGenie integration]

--- a/lib/openshift4-monitoring-alert-patching.libsonnet
+++ b/lib/openshift4-monitoring-alert-patching.libsonnet
@@ -1,0 +1,162 @@
+// Component library providing generally applicable functions which adjust
+// arbitrary alert rules to adhere to the format required by the component's
+// approach for allowing us to patch upstream rules.
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+
+local inv = kap.inventory();
+
+local global_alert_params =
+  std.get(
+    inv.parameters,
+    'openshift4_monitoring',
+    { alerts: { ignoreNames: [] } }
+  ).alerts;
+
+/**
+ * \brief filter alert rules in the provided group
+ *
+ * The function assumes that `group` is a valid entry for the PrometheusRule
+ * CR `.spec.groups` field.
+ *
+ * \arg group
+ *        a PrometheusRule CR `.spec.groups` entry
+ * \arg ignoreNames
+ *        A list of alert names to filter out. This argument is optional and
+ *        defaults to the empty list.  The function doesn't process the
+ *        provided value for `ignoreNames`, except converting it to a Jsonnet
+ *        set with `std.set()`.  If you want to use `com.renderArray()` to
+ *        allow re-enabling ignored alerts, you'll have to do so before
+ *        providing the list to the function.
+ * \arg preserveRecordingRules
+ *        Whether to keep or discard recording rules in the group. This
+ *        argument is optional and defaults to `false`. This is useful when
+ *        wanting to patch alerting rules which are already deployed to the
+ *        cluster through some operator (e.g. cluster-logging, or rook-ceph).
+ *        Generally, in such cases, we'll only want to modify alerting rules,
+ *        but don't want to deploy duplicates of the recording rules which may
+ *        be present in the same groups as the alerting rules in the upstream
+ *        manifests.
+ *
+ * \returns
+ *    The group with alert rules whose field `alert` matches an entry in either
+ *    component parameter `openshift4_monitoring.alerts.ignoreNames` or the
+ *    function argument `ignoreNames` list removed. If `preserveRecordingRules`
+ *    is `false`, all recording rules are also removed from the result.
+ */
+local filterRules(group, ignoreNames=[], preserveRecordingRules=false) =
+  local filterRecording(rule) =
+    if preserveRecordingRules then
+      true
+    else
+      // only create duplicates of alert rules
+      std.objectHas(rule, 'alert');
+  local ignore_set = std.set(global_alert_params.ignoreNames + ignoreNames);
+  group {
+    rules:
+      std.filter(
+        // Filter out unwanted rules
+        function(rule)
+          filterRecording(rule) &&
+          !std.member(ignore_set, rule.alert),
+        super.rules
+      ),
+  };
+
+/**
+ * \brief patch the provided rule to adhere to the format expected by the
+ *        component.
+ *
+ * This function patches the provided alert rule to adhere to the format
+ * expected by this component. This includes adding labels which are used by
+ * other parts of the component to the rule (e.g. `syn=true`), as well as
+ * ensuring that the alert name is prefixed with `SYN_`.
+ *
+ * Custom alert patches can be provided through argument `patches`.
+ *
+ * Recording rules will always be returned unchanged
+ *
+ * \arg rule
+ *        The rule to patch
+ * \arg patches
+ *        An object with partial alert rule definitions. The function uses the
+ *        provided rule's `alert` field to lookup potential patches. This
+ *        parameter is optional and defaults to an empty object.
+ * \arg patchName
+ *        Whether to prefix the alert name with `SYN_` if it isn't already.
+ *        This parameter is optional and defaults to `true`.
+ *
+ * \returns The patched rule
+ */
+local patchRule(rule, patches={}, patchName=true) =
+  if !std.objectHas(rule, 'alert') then
+    rule
+  else
+    local rulepatch = std.get(patches, rule.alert, {});
+    local fixupName(name) =
+      if patchName && !std.startsWith(name, 'SYN_') then
+        'SYN_' + name
+      else
+        name;
+    rule {
+      // Change alert names so we don't get multiple alerts with the same
+      // name, as the logging operator deploys its own copy of these
+      // rules.
+      alert: fixupName(super.alert),
+      labels+: {
+        syn: 'true',
+        // mark alert as belonging to component instance in whose context the
+        // function is called.
+        syn_component: inv.parameters._instance,
+      },
+    } + com.makeMergeable(rulepatch);
+
+/**
+ * \brief Convenience wrapper around filterRules and patchRule.
+ *
+ * This function provides a convenience wrapper which filters the provided
+ * group using `filterRules`, and applies `patchRule` for each rule which
+ * isn't dropped by `filterRules`.
+ *
+ * \arg group
+ *        a PrometheusRule CR `.spec.groups` entry
+ * \arg ignoreNames
+ *        A list of alert names to filter out. This argument is optional and
+ *        defaults to the empty list.  The function doesn't process the
+ *        provided value for `ignoreNames`, except converting it to a Jsonnet
+ *        set with `std.set()`.  If you want to use `com.renderArray()` to
+ *        allow re-enabling ignored alerts, you'll have to do so before
+ *        providing the list to the function.
+ * \arg patches
+ *        An object with partial alert rule definitions. The function uses the
+ *        provided rule's `alert` field to lookup potential patches. This
+ *        parameter is optional and defaults to an empty object.
+ * \arg preserveRecordingRules
+ *        Whether to keep or discard recording rules in the group. This
+ *        argument is optional and defaults to `false`. This is useful when
+ *        wanting to patch alerting rules which are already deployed to the
+ *        cluster through some operator (e.g. cluster-logging, or rook-ceph).
+ *        Generally, in such cases, we'll only want to modify alerting rules,
+ *        but don't want to deploy duplicates of the recording rules which may
+ *        be present in the same groups as the alerting rules in the upstream
+ *        manifests.
+ * \arg patchNames
+ *        Whether to prefix alert names with `SYN_` if they aren't already.
+ *        This parameter is passed to `patchRule()` as argument `patchName`.
+ *        This parameter is optional and defaults to `true`.
+ *
+ * \returns the provided `group` object with rules filtered and patched
+ */
+local filterPatchRules(group, ignoreNames=[], patches={}, preserveRecordingRules=false, patchNames=true) =
+  filterRules(group, ignoreNames, preserveRecordingRules) {
+    rules: std.map(
+      function(rule) patchRule(rule, patches, patchNames),
+      super.rules
+    ),
+  };
+
+{
+  filterRules: filterRules,
+  patchRule: patchRule,
+  filterPatchRules: filterPatchRules,
+}

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -26,6 +26,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorInsufficientCloudCreds
           annotations:
             description: The Cloud Credential Operator has determined that there are
@@ -42,6 +43,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorProvisioningFailed
           annotations:
             description: While processing a CredentialsRequest, the Cloud Credential
@@ -58,6 +60,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorStaleCredentials
           annotations:
             description: The Cloud Credential Operator (CCO) has detected one or more
@@ -82,6 +85,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorTargetNamespaceMissing
           annotations:
             description: At least one CredentialsRequest custom resource has specified
@@ -101,6 +105,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-ImageRegistryOperator
       rules:
         - alert: SYN_ImageRegistryStorageReconfigured
@@ -117,6 +122,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-SamplesOperator
       rules:
         - alert: SYN_SamplesDegraded
@@ -131,6 +137,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesImagestreamImportFailing
           annotations:
             message: "Samples operator is detecting problems with imagestream image\
@@ -149,6 +156,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesInvalidConfig
           annotations:
             message: 'Samples operator has been given an invalid configuration.
@@ -160,6 +168,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesMissingSecret
           annotations:
             message: 'Samples operator cannot find the samples pull secret in the
@@ -172,6 +181,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesMissingTBRCredential
           annotations:
             message: 'The samples operator cannot find credentials for ''registry.redhat.io''.
@@ -186,6 +196,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesRetriesMissingOnImagestreamImportFailing
           annotations:
             message: "Samples operator is detecting problems with imagestream image\
@@ -206,6 +217,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesTBRInaccessibleOnBoot
           annotations:
             message: 'One of two situations has occurred.  Either
@@ -240,6 +252,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-alertmanager.rules
       rules:
         - alert: SYN_AlertmanagerClusterDown
@@ -258,6 +271,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -274,6 +288,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -288,6 +303,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerFailedReload
           annotations:
             description: Configuration has failed to load for {{ $labels.namespace
@@ -309,6 +325,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -323,6 +340,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -340,6 +358,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-apiserver-requests-in-flight
       rules: []
     - name: syn-cluster-machine-approver.rules
@@ -367,6 +386,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-network-operator-sdn.rules
       rules:
         - alert: SYN_ClusterProxyApplySlow
@@ -381,6 +401,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeProxyApplySlow
           annotations:
             summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node
@@ -396,6 +417,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeProxyApplyStale
           annotations:
             summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node
@@ -412,6 +434,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeWithoutSDNController
           annotations:
             summary: All control plane nodes should be running a sdn controller pod,
@@ -424,6 +447,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeWithoutSDNPod
           annotations:
             summary: All nodes should be running an sdn pod, {{"{{"}} $labels.node
@@ -437,6 +461,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SDNPodNotReady
           annotations:
             summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node
@@ -450,6 +475,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-operators
       rules:
         - alert: SYN_ClusterNotUpgradeable
@@ -475,6 +501,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorDegraded
           annotations:
             description: The {{ $labels.name }} operator is degraded because {{ $labels.reason
@@ -493,6 +520,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorDown
           annotations:
             description: The {{ $labels.name }} operator may be down or disabled,
@@ -511,6 +539,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorFlapping
           annotations:
             description: The  {{ $labels.name }} operator behavior might cause upgrades
@@ -528,6 +557,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-version
       rules:
         - alert: SYN_CannotRetrieveUpdates
@@ -555,6 +585,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterVersionOperatorDown
           annotations:
             description: The operator may be down or disabled. The cluster will not
@@ -574,6 +605,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeControllerManagerDown
           annotations:
             description: KubeControllerManager has disappeared from Prometheus target
@@ -589,6 +621,7 @@ spec:
             namespace: openshift-kube-controller-manager
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeSchedulerDown
           annotations:
             description: KubeScheduler has disappeared from Prometheus target discovery.
@@ -602,6 +635,7 @@ spec:
             namespace: openshift-kube-scheduler
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PodDisruptionBudgetAtLimit
           annotations:
             description: The pod disruption budget is at the minimum disruptions allowed
@@ -620,6 +654,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PodDisruptionBudgetLimit
           annotations:
             description: The pod disruption budget is below the minimum disruptions
@@ -636,6 +671,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_TechPreviewNoUpgrade
           annotations:
             description: Cluster has enabled Technology Preview features that cannot
@@ -651,6 +687,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_UpdateAvailable
           annotations:
             description: For more information refer to 'oc adm upgrade'{{ with $console_url
@@ -666,6 +703,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-config-reloaders
       rules:
         - alert: SYN_ConfigReloaderSidecarErrors
@@ -685,6 +723,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-control-plane-cpu-utilization
       rules:
         - alert: SYN_ExtremelyHighIndividualControlPlaneCPU
@@ -712,6 +751,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ExtremelyHighIndividualControlPlaneCPU
           annotations:
             description: Extreme CPU pressure can cause slow serialization and poor
@@ -737,6 +777,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_HighOverallControlPlaneCPU
           annotations:
             description: Given three control plane nodes, the overall CPU utilization
@@ -760,6 +801,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-etcd
       rules:
         - alert: SYN_etcdDatabaseHighFragmentationRatio
@@ -780,6 +822,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdDatabaseQuotaLowSpace
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": database size exceeds
@@ -797,6 +840,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdExcessiveDatabaseGrowth
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": Predicting running out
@@ -812,6 +856,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighCommitDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit
@@ -827,6 +872,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighFsyncDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
@@ -842,6 +888,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighFsyncDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
@@ -858,6 +905,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedProposals
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }} proposal
@@ -873,6 +921,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdMemberCommunicationSlow
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": member communication with
@@ -889,6 +938,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdMembersDown
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value
@@ -903,6 +953,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdNoLeader
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": member {{ $labels.instance
@@ -917,6 +968,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-general.rules
       rules:
         - alert: Watchdog
@@ -944,6 +996,7 @@ spec:
             namespace: openshift-monitoring
             severity: none
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-k8s.rules
       rules: []
     - name: syn-kube-apiserver-slos-basic
@@ -972,6 +1025,7 @@ spec:
             severity: critical
             short: 5m
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget. This alert
@@ -996,6 +1050,7 @@ spec:
             severity: critical
             short: 30m
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kube-apiserver.rules
       rules: []
     - name: syn-kube-prometheus-general.rules
@@ -1020,6 +1075,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -1034,6 +1090,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubelet.rules
       rules: []
     - name: syn-kubernetes-apps
@@ -1053,6 +1110,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -1067,6 +1125,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -1080,6 +1139,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -1104,6 +1164,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -1118,6 +1179,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeHpaMaxedOut
           annotations:
             description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
@@ -1131,6 +1193,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeHpaReplicasMismatch
           annotations:
             description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
@@ -1153,6 +1216,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeJobCompletion
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -1168,6 +1232,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -1184,6 +1249,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePodCrashLooping
           annotations:
             description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
@@ -1199,6 +1265,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -1215,6 +1282,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1229,6 +1297,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1245,6 +1314,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1264,6 +1334,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-recurring.rules
       rules: []
     - name: syn-kubernetes-resources
@@ -1288,6 +1359,7 @@ spec:
             namespace: kube-system
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeCPUQuotaOvercommit
           annotations:
             description: Cluster has overcommitted CPU resource requests for Namespaces.
@@ -1301,6 +1373,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeMemoryOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Pods
@@ -1322,6 +1395,7 @@ spec:
             namespace: kube-system
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Namespaces.
@@ -1335,6 +1409,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1349,6 +1424,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1363,6 +1439,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1377,6 +1454,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-storage
       rules:
         - alert: SYN_KubePersistentVolumeErrors
@@ -1393,6 +1471,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -1415,6 +1494,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -1440,6 +1520,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system
       rules:
         - alert: SYN_KubeClientErrors
@@ -1455,6 +1536,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system-apiserver
       rules:
         - alert: SYN_KubeAPIDown
@@ -1470,6 +1552,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -1486,6 +1569,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -1500,6 +1584,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -1514,6 +1599,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system-kubelet
       rules:
         - alert: SYN_KubeNodeNotReady
@@ -1530,6 +1616,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -1544,6 +1631,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -1559,6 +1647,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -1573,6 +1662,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -1587,6 +1677,7 @@ spec:
             namespace: kube-system
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -1601,6 +1692,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -1616,6 +1708,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -1629,6 +1722,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -1644,6 +1738,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-api-operator-metrics-collector-up
       rules:
         - alert: SYN_MachineAPIOperatorMetricsCollectionFailing
@@ -1659,6 +1754,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-health-check-unterminated-short-circuit
       rules:
         - alert: SYN_MachineHealthCheckUnterminatedShortCircuit
@@ -1679,6 +1775,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-not-yet-deleted
       rules:
         - alert: SYN_MachineNotYetDeleted
@@ -1703,6 +1800,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-with-no-running-phase
       rules:
         - alert: SYN_MachineWithNoRunningPhase
@@ -1726,6 +1824,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-without-valid-node-ref
       rules:
         - alert: SYN_MachineWithoutValidNode
@@ -1747,6 +1846,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-master-nodes-high-memory-usage
       rules:
         - alert: SYN_MasterNodesHighMemoryUsage
@@ -1768,6 +1868,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-drain-error
       rules:
         - alert: SYN_MCDDrainError
@@ -1782,6 +1883,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-kubelet-health-state-error
       rules:
         - alert: SYN_KubeletHealthState
@@ -1794,6 +1896,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-pivot-error
       rules:
         - alert: SYN_MCDPivotError
@@ -1806,6 +1909,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-reboot-error
       rules:
         - alert: SYN_MCDRebootError
@@ -1818,6 +1922,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-exporter
       rules:
         - alert: SYN_NodeClockNotSynchronising
@@ -1837,6 +1942,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeClockSkewDetected
           annotations:
             description: Clock on {{ $labels.instance }} is out of sync by more than
@@ -1850,6 +1956,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -1863,6 +1970,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -1876,6 +1984,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1891,6 +2000,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1906,6 +2016,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1921,6 +2032,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1936,6 +2048,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1954,6 +2067,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1972,6 +2086,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1990,6 +2105,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2008,6 +2124,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $value | humanizePercentage }} of conntrack entries are
@@ -2020,6 +2137,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -2035,6 +2153,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -2050,6 +2169,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' on {{ $labels.instance
@@ -2066,6 +2186,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array on {{ $labels.instance
@@ -2079,6 +2200,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector failed to scrape.
@@ -2090,6 +2212,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-exporter.rules
       rules: []
     - name: syn-node-network
@@ -2109,6 +2232,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-utilization
       rules:
         - alert: SYN_node_cpu_load5
@@ -2122,6 +2246,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_node_memory_free_percent
           annotations:
             message: '{{ $labels.node }}: Memory usage more than 97% (current value
@@ -2133,6 +2258,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node.rules
       rules: []
     - name: syn-olm.failing_operators.rules
@@ -2146,6 +2272,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-build.rules
       rules: []
     - name: syn-openshift-etcd-telemetry.rules
@@ -2170,6 +2297,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedGRPCRequests
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
@@ -2185,6 +2313,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedGRPCRequests
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
@@ -2201,6 +2330,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfLeaderChanges
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }} average leader
@@ -2216,6 +2346,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdInsufficientMembers
           annotations:
             description: etcd is reporting fewer instances are available than are
@@ -2236,6 +2367,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-general.rules
       rules:
         - alert: SYN_TargetDown
@@ -2257,6 +2389,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-ingress.rules
       rules:
         - alert: SYN_HAProxyDown
@@ -2271,6 +2404,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_HAProxyReloadFail
           annotations:
             description: This alert fires when HAProxy fails to reload its configuration,
@@ -2285,6 +2419,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_IngressControllerDegraded
           annotations:
             description: This alert fires when the IngressController status is degraded.
@@ -2301,6 +2436,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_IngressControllerUnavailable
           annotations:
             description: This alert fires when the IngressController is not available.
@@ -2317,6 +2453,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-kubernetes.rules
       rules:
         - alert: SYN_AlertmanagerReceiversNotConfigured
@@ -2333,6 +2470,7 @@ spec:
             namespace: openshift-monitoring
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterMonitoringOperatorReconciliationErrors
           annotations:
             description: Errors are occurring during reconciliation cycles. Inspect
@@ -2346,6 +2484,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -2370,6 +2509,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_MultipleContainersOOMKilled
           annotations:
             description: Multiple containers were out of memory killed within the
@@ -2385,6 +2525,7 @@ spec:
             namespace: kube-system
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-monitoring.rules
       rules: []
     - name: syn-openshift-sre.rules
@@ -2412,6 +2553,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_APIRemovedInNextReleaseInUse
           annotations:
             description: Deprecated API that will be removed in the next version is
@@ -2433,6 +2575,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-prometheus
       rules:
         - alert: SYN_PrometheusBadConfig
@@ -2455,6 +2598,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -2470,6 +2614,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -2485,6 +2630,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -2501,6 +2647,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -2516,6 +2663,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -2536,6 +2684,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -2551,6 +2700,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -2567,6 +2717,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -2582,6 +2733,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -2600,6 +2752,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -2617,6 +2770,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -2636,6 +2790,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -2650,6 +2805,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -2664,6 +2820,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -2678,6 +2835,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -2694,6 +2852,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -2709,6 +2868,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-prometheus-operator
       rules:
         - alert: SYN_PrometheusOperatorListErrors
@@ -2728,6 +2888,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -2743,6 +2904,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -2758,6 +2920,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -2776,6 +2939,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -2792,6 +2956,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -2807,6 +2972,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -2824,6 +2990,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-scheduler-legacy-policy-deprecated
       rules:
         - alert: SYN_SchedulerLegacyPolicySet
@@ -2839,6 +3006,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-system-memory-exceeds-reservation
       rules:
         - alert: SYN_SystemMemoryExceedsReservation
@@ -2861,6 +3029,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-thanos-query
       rules:
         - alert: SYN_ThanosQueryGrpcClientErrorRate
@@ -2876,6 +3045,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryGrpcServerErrorRate
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
@@ -2890,6 +3060,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHighDNSFailures
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} have
@@ -2903,6 +3074,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHttpRequestQueryErrorRateHigh
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
@@ -2917,6 +3089,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHttpRequestQueryRangeErrorRateHigh
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
@@ -2931,6 +3104,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-thanos-rule
       rules:
         - alert: SYN_ThanosNoRuleEvaluations
@@ -2946,6 +3120,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleAlertmanagerHighDNSFailures
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -2959,6 +3134,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleConfigReloadFailure
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
@@ -2971,6 +3147,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleGrpcErrorRate
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} is failing
@@ -2986,6 +3163,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleHighRuleEvaluationFailures
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -2999,6 +3177,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleHighRuleEvaluationWarnings
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3013,6 +3192,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleNoEvaluationFor10Intervals
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
@@ -3031,6 +3211,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleQueryHighDNSFailures
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
@@ -3044,6 +3225,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleQueueIsDroppingAlerts
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3059,6 +3241,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleRuleEvaluationLatencyHigh
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3073,6 +3256,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleSenderIsFailingAlerts
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3087,3 +3271,4 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/es-operator-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/es-operator-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -26,6 +26,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorInsufficientCloudCreds
           annotations:
             description: The Cloud Credential Operator has determined that there are
@@ -42,6 +43,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorProvisioningFailed
           annotations:
             description: While processing a CredentialsRequest, the Cloud Credential
@@ -58,6 +60,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorStaleCredentials
           annotations:
             description: The Cloud Credential Operator (CCO) has detected one or more
@@ -82,6 +85,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorTargetNamespaceMissing
           annotations:
             description: At least one CredentialsRequest custom resource has specified
@@ -101,6 +105,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-SamplesOperator
       rules:
         - alert: SYN_SamplesDegraded
@@ -116,6 +121,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesImagestreamImportFailing
           annotations:
             description: "Samples operator is detecting problems with imagestream\
@@ -137,6 +143,7 @@ spec:
             namespace: openshift-cluster-samples-operator
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesInvalidConfig
           annotations:
             description: 'Samples operator has been given an invalid configuration.
@@ -149,6 +156,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesMissingSecret
           annotations:
             description: 'Samples operator cannot find the samples pull secret in
@@ -162,6 +170,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesMissingTBRCredential
           annotations:
             description: 'The samples operator cannot find credentials for ''registry.redhat.io''.
@@ -177,6 +186,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesRetriesMissingOnImagestreamImportFailing
           annotations:
             description: "Samples operator is detecting problems with imagestream\
@@ -200,6 +210,7 @@ spec:
             namespace: openshift-cluster-samples-operator
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesTBRInaccessibleOnBoot
           annotations:
             description: 'One of two situations has occurred.  Either
@@ -237,6 +248,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-alertmanager.rules
       rules:
         - alert: SYN_AlertmanagerClusterDown
@@ -255,6 +267,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -272,6 +285,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -286,6 +300,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerFailedReload
           annotations:
             description: Configuration has failed to load for {{ $labels.namespace
@@ -307,6 +322,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -322,6 +338,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -339,6 +356,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-apiserver-requests-in-flight
       rules: []
     - name: syn-cluster-machine-approver.rules
@@ -366,6 +384,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-network-operator-sdn.rules
       rules:
         - alert: SYN_ClusterProxyApplySlow
@@ -383,6 +402,7 @@ spec:
             namespace: openshift-sdn
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeProxyApplySlow
           annotations:
             description: Configuration of proxy rules for Kubernetes services in the
@@ -399,6 +419,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeProxyApplyStale
           annotations:
             description: Stale proxy rules for Kubernetes services may increase the
@@ -417,6 +438,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeWithoutSDNController
           annotations:
             description: 'If at least one OpenShift SDN controller is ''Running'',
@@ -435,6 +457,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeWithoutSDNPod
           annotations:
             description: Network control plane configuration on the node could be
@@ -450,6 +473,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SDNPodNotReady
           annotations:
             description: Network control plane configuration on the node could be
@@ -465,6 +489,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-operators
       rules:
         - alert: SYN_ClusterNotUpgradeable
@@ -490,6 +515,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorDegraded
           annotations:
             description: The {{ $labels.name }} operator is degraded because {{ $labels.reason
@@ -508,6 +534,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorDown
           annotations:
             description: The {{ $labels.name }} operator may be down or disabled,
@@ -526,6 +553,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorFlapping
           annotations:
             description: The  {{ $labels.name }} operator behavior might cause upgrades
@@ -543,6 +571,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-version
       rules:
         - alert: SYN_CannotRetrieveUpdates
@@ -570,6 +599,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterVersionOperatorDown
           annotations:
             description: The operator may be down or disabled. The cluster will not
@@ -589,6 +619,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_GarbageCollectorSyncFailed
           annotations:
             description: Garbage Collector had a problem with syncing and monitoring
@@ -605,6 +636,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeControllerManagerDown
           annotations:
             description: KubeControllerManager has disappeared from Prometheus target
@@ -620,6 +652,7 @@ spec:
             namespace: openshift-kube-controller-manager
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeSchedulerDown
           annotations:
             description: KubeScheduler has disappeared from Prometheus target discovery.
@@ -633,6 +666,7 @@ spec:
             namespace: openshift-kube-scheduler
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PodDisruptionBudgetAtLimit
           annotations:
             description: The pod disruption budget is at the minimum disruptions allowed
@@ -651,6 +685,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PodDisruptionBudgetLimit
           annotations:
             description: The pod disruption budget is below the minimum disruptions
@@ -667,6 +702,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_TechPreviewNoUpgrade
           annotations:
             description: Cluster has enabled Technology Preview features that cannot
@@ -682,6 +718,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_UpdateAvailable
           annotations:
             description: For more information refer to 'oc adm upgrade'{{ with $console_url
@@ -697,6 +734,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-config-reloaders
       rules:
         - alert: SYN_ConfigReloaderSidecarErrors
@@ -716,6 +754,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-control-plane-cpu-utilization
       rules:
         - alert: SYN_ExtremelyHighIndividualControlPlaneCPU
@@ -743,6 +782,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ExtremelyHighIndividualControlPlaneCPU
           annotations:
             description: Extreme CPU pressure can cause slow serialization and poor
@@ -768,6 +808,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_HighOverallControlPlaneCPU
           annotations:
             description: Given three control plane nodes, the overall CPU utilization
@@ -791,6 +832,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-etcd
       rules:
         - alert: SYN_etcdDatabaseHighFragmentationRatio
@@ -811,6 +853,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdDatabaseQuotaLowSpace
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": database size exceeds
@@ -828,6 +871,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdExcessiveDatabaseGrowth
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": Predicting running out
@@ -843,6 +887,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighCommitDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit
@@ -858,6 +903,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighFsyncDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
@@ -873,6 +919,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighFsyncDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
@@ -889,6 +936,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedProposals
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }} proposal
@@ -904,6 +952,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdMemberCommunicationSlow
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": member communication with
@@ -920,6 +969,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdMembersDown
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value
@@ -934,6 +984,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdNoLeader
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": member {{ $labels.instance
@@ -948,6 +999,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-extremely-high-individual-control-plane-memory
       rules:
         - alert: SYN_ExtremelyHighIndividualControlPlaneMemory
@@ -974,6 +1026,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-general.rules
       rules:
         - alert: Watchdog
@@ -1001,6 +1054,7 @@ spec:
             namespace: openshift-monitoring
             severity: none
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-high-overall-control-plane-memory
       rules:
         - alert: SYN_HighOverallControlPlaneMemory
@@ -1039,6 +1093,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-k8s.rules
       rules: []
     - name: syn-kube-apiserver-slos-basic
@@ -1067,6 +1122,7 @@ spec:
             severity: critical
             short: 5m
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget. This alert
@@ -1091,6 +1147,7 @@ spec:
             severity: critical
             short: 30m
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kube-apiserver.rules
       rules: []
     - name: syn-kube-prometheus-general.rules
@@ -1115,6 +1172,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -1129,6 +1187,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubelet.rules
       rules: []
     - name: syn-kubernetes-apps
@@ -1148,6 +1207,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -1162,6 +1222,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -1175,6 +1236,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -1199,6 +1261,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -1213,6 +1276,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeHpaMaxedOut
           annotations:
             description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
@@ -1226,6 +1290,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeHpaReplicasMismatch
           annotations:
             description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
@@ -1248,6 +1313,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -1264,6 +1330,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeJobNotCompleted
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -1277,6 +1344,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePodCrashLooping
           annotations:
             description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
@@ -1292,6 +1360,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -1309,6 +1378,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1323,6 +1393,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1339,6 +1410,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1358,6 +1430,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-recurring.rules
       rules: []
     - name: syn-kubernetes-resources
@@ -1382,6 +1455,7 @@ spec:
             namespace: kube-system
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeCPUQuotaOvercommit
           annotations:
             description: Cluster has overcommitted CPU resource requests for Namespaces.
@@ -1395,6 +1469,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeMemoryOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Pods
@@ -1416,6 +1491,7 @@ spec:
             namespace: kube-system
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Namespaces.
@@ -1429,6 +1505,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1443,6 +1520,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1457,6 +1535,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1471,6 +1550,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-storage
       rules:
         - alert: SYN_KubePersistentVolumeErrors
@@ -1487,6 +1567,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -1509,6 +1590,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -1534,6 +1616,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeInodesFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -1556,6 +1639,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeInodesFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -1581,6 +1665,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system
       rules:
         - alert: SYN_KubeClientErrors
@@ -1596,6 +1681,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system-apiserver
       rules:
         - alert: SYN_KubeAPIDown
@@ -1611,6 +1697,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -1627,6 +1714,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -1641,6 +1729,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -1655,6 +1744,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system-kubelet
       rules:
         - alert: SYN_KubeNodeNotReady
@@ -1671,6 +1761,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -1685,6 +1776,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -1700,6 +1792,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -1714,6 +1807,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -1728,6 +1822,7 @@ spec:
             namespace: kube-system
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -1742,6 +1837,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -1758,6 +1854,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -1771,6 +1868,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -1786,6 +1884,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-logging_elasticsearch.alerts
       rules:
         - alert: SYN_AggregatedLoggingSystemCPUHigh
@@ -1803,6 +1902,7 @@ spec:
             namespace: openshift-logging
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ElasticsearchClusterNotHealthy
           annotations:
             message: Cluster {{ $labels.cluster }} health status has been RED for
@@ -1819,6 +1919,7 @@ spec:
             namespace: openshift-logging
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ElasticsearchClusterNotHealthy
           annotations:
             message: Cluster {{ $labels.cluster }} health status has been YELLOW for
@@ -1834,6 +1935,7 @@ spec:
             namespace: openshift-logging
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ElasticsearchDiskSpaceRunningLow
           annotations:
             message: Cluster {{ $labels.cluster }} is predicted to be out of disk
@@ -1849,6 +1951,7 @@ spec:
             namespace: openshift-logging
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ElasticsearchHighFileDescriptorUsage
           annotations:
             message: Cluster {{ $labels.cluster }} is predicted to be out of file
@@ -1866,6 +1969,7 @@ spec:
             namespace: openshift-logging
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ElasticsearchJVMHeapUseHigh
           annotations:
             message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
@@ -1882,6 +1986,7 @@ spec:
             namespace: openshift-logging
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ElasticsearchNodeDiskWatermarkReached
           annotations:
             message: Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can
@@ -1898,6 +2003,7 @@ spec:
             namespace: openshift-logging
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ElasticsearchNodeDiskWatermarkReached
           annotations:
             message: Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards
@@ -1915,6 +2021,7 @@ spec:
             namespace: openshift-logging
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ElasticsearchNodeDiskWatermarkReached
           annotations:
             message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every
@@ -1933,6 +2040,7 @@ spec:
             namespace: openshift-logging
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ElasticsearchNodeDiskWatermarkReached
           annotations:
             message: Disk Low Watermark is predicted to be reached within the next
@@ -1949,6 +2057,7 @@ spec:
             namespace: openshift-logging
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ElasticsearchNodeDiskWatermarkReached
           annotations:
             message: Disk High Watermark is predicted to be reached within the next
@@ -1966,6 +2075,7 @@ spec:
             namespace: openshift-logging
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ElasticsearchNodeDiskWatermarkReached
           annotations:
             message: Disk Flood Stage Watermark is predicted to be reached within
@@ -1984,6 +2094,7 @@ spec:
             namespace: openshift-logging
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ElasticsearchOperatorCSVNotSuccessful
           annotations:
             message: Elasticsearch Operator CSV has not reconciled succesfully.
@@ -1997,6 +2108,7 @@ spec:
             namespace: openshift-logging
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ElasticsearchProcessCPUHigh
           annotations:
             message: ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
@@ -2012,6 +2124,7 @@ spec:
             namespace: openshift-logging
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ElasticsearchWriteRequestsRejectionJumps
           annotations:
             message: High Write Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster
@@ -2027,6 +2140,7 @@ spec:
             namespace: openshift-logging
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-api-operator-metrics-collector-up
       rules:
         - alert: SYN_MachineAPIOperatorMetricsCollectionFailing
@@ -2042,6 +2156,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-health-check-unterminated-short-circuit
       rules:
         - alert: SYN_MachineHealthCheckUnterminatedShortCircuit
@@ -2062,6 +2177,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-not-yet-deleted
       rules:
         - alert: SYN_MachineNotYetDeleted
@@ -2086,6 +2202,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-with-no-running-phase
       rules:
         - alert: SYN_MachineWithNoRunningPhase
@@ -2109,6 +2226,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-without-valid-node-ref
       rules:
         - alert: SYN_MachineWithoutValidNode
@@ -2130,6 +2248,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcc-paused-pool-kubelet-ca
       rules:
         - alert: SYN_MachineConfigControllerPausedPoolKubeletCA
@@ -2160,6 +2279,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_MachineConfigControllerPausedPoolKubeletCA
           annotations:
             description: Machine config pools have a 'pause' feature, which allows
@@ -2190,6 +2310,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-drain-error
       rules:
         - alert: SYN_MCDDrainError
@@ -2204,6 +2325,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-kubelet-health-state-error
       rules:
         - alert: SYN_KubeletHealthState
@@ -2216,6 +2338,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-pivot-error
       rules:
         - alert: SYN_MCDPivotError
@@ -2228,6 +2351,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-reboot-error
       rules:
         - alert: SYN_MCDRebootError
@@ -2240,6 +2364,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-exporter
       rules:
         - alert: SYN_NodeClockNotSynchronising
@@ -2260,6 +2385,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeClockSkewDetected
           annotations:
             description: Clock on {{ $labels.instance }} is out of sync by more than
@@ -2273,6 +2399,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -2286,6 +2413,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -2299,6 +2427,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2314,6 +2443,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2329,6 +2459,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2344,6 +2475,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2359,6 +2491,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2377,6 +2510,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2395,6 +2529,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2413,6 +2548,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2431,6 +2567,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $value | humanizePercentage }} of conntrack entries are
@@ -2443,6 +2580,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -2458,6 +2596,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -2473,6 +2612,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' on {{ $labels.instance
@@ -2489,6 +2629,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array on {{ $labels.instance
@@ -2502,6 +2643,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector failed to scrape.
@@ -2513,6 +2655,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-exporter.rules
       rules: []
     - name: syn-node-network
@@ -2532,6 +2675,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-utilization
       rules:
         - alert: SYN_node_cpu_load5
@@ -2545,6 +2689,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_node_memory_free_percent
           annotations:
             message: '{{ $labels.node }}: Memory usage more than 97% (current value
@@ -2556,6 +2701,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node.rules
       rules: []
     - name: syn-olm.failing_operators.rules
@@ -2569,6 +2715,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-build.rules
       rules: []
     - name: syn-openshift-etcd-telemetry.rules
@@ -2593,6 +2740,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedGRPCRequests
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
@@ -2608,6 +2756,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedGRPCRequests
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
@@ -2624,6 +2773,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfLeaderChanges
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }} average leader
@@ -2639,6 +2789,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdInsufficientMembers
           annotations:
             description: etcd is reporting fewer instances are available than are
@@ -2659,6 +2810,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-general.rules
       rules:
         - alert: SYN_TargetDown
@@ -2680,6 +2832,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-ingress.rules
       rules:
         - alert: SYN_HAProxyDown
@@ -2694,6 +2847,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_HAProxyReloadFail
           annotations:
             description: This alert fires when HAProxy fails to reload its configuration,
@@ -2708,6 +2862,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_IngressControllerDegraded
           annotations:
             description: This alert fires when the IngressController status is degraded.
@@ -2724,6 +2879,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_IngressControllerUnavailable
           annotations:
             description: This alert fires when the IngressController is not available.
@@ -2740,6 +2896,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-kubernetes.rules
       rules:
         - alert: SYN_AlertmanagerReceiversNotConfigured
@@ -2756,6 +2913,7 @@ spec:
             namespace: openshift-monitoring
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterMonitoringOperatorReconciliationErrors
           annotations:
             description: Errors are occurring during reconciliation cycles. Inspect
@@ -2769,6 +2927,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -2793,6 +2952,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_MultipleContainersOOMKilled
           annotations:
             description: Multiple containers were out of memory killed within the
@@ -2808,6 +2968,7 @@ spec:
             namespace: kube-system
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-monitoring.rules
       rules: []
     - name: syn-openshift-sre.rules
@@ -2835,6 +2996,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_APIRemovedInNextReleaseInUse
           annotations:
             description: Deprecated API that will be removed in the next version is
@@ -2856,6 +3018,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-prometheus
       rules:
         - alert: SYN_PrometheusBadConfig
@@ -2878,6 +3041,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -2893,6 +3057,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -2908,6 +3073,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -2924,6 +3090,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -2939,6 +3106,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -2959,6 +3127,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -2974,6 +3143,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -2990,6 +3160,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -3005,6 +3176,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -3023,6 +3195,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -3040,6 +3213,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -3059,6 +3233,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -3073,6 +3248,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusScrapeBodySizeLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -3088,6 +3264,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusScrapeSampleLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -3104,6 +3281,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -3118,6 +3296,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -3132,6 +3311,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -3148,6 +3328,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -3163,6 +3344,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-prometheus-operator
       rules:
         - alert: SYN_PrometheusOperatorListErrors
@@ -3182,6 +3364,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -3197,6 +3380,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -3212,6 +3396,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -3230,6 +3415,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -3246,6 +3432,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -3261,6 +3448,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -3278,6 +3466,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-scheduler-legacy-policy-deprecated
       rules:
         - alert: SYN_SchedulerLegacyPolicySet
@@ -3293,6 +3482,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-system-memory-exceeds-reservation
       rules:
         - alert: SYN_SystemMemoryExceedsReservation
@@ -3315,6 +3505,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-thanos-query
       rules:
         - alert: SYN_ThanosQueryGrpcClientErrorRate
@@ -3330,6 +3521,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryGrpcServerErrorRate
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
@@ -3344,6 +3536,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHighDNSFailures
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} have
@@ -3357,6 +3550,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHttpRequestQueryErrorRateHigh
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
@@ -3371,6 +3565,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHttpRequestQueryRangeErrorRateHigh
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
@@ -3385,6 +3580,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-thanos-rule
       rules:
         - alert: SYN_ThanosNoRuleEvaluations
@@ -3400,6 +3596,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleAlertmanagerHighDNSFailures
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3413,6 +3610,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleConfigReloadFailure
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
@@ -3425,6 +3623,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleGrpcErrorRate
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} is failing
@@ -3440,6 +3639,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleHighRuleEvaluationFailures
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3453,6 +3653,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleHighRuleEvaluationWarnings
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3467,6 +3668,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleNoEvaluationFor10Intervals
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
@@ -3485,6 +3687,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleQueryHighDNSFailures
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
@@ -3498,6 +3701,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleQueueIsDroppingAlerts
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3513,6 +3717,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleRuleEvaluationLatencyHigh
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3527,6 +3732,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleSenderIsFailingAlerts
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3541,3 +3747,4 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -26,6 +26,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorInsufficientCloudCreds
           annotations:
             description: The Cloud Credential Operator has determined that there are
@@ -42,6 +43,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorProvisioningFailed
           annotations:
             description: While processing a CredentialsRequest, the Cloud Credential
@@ -58,6 +60,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorStaleCredentials
           annotations:
             description: The Cloud Credential Operator (CCO) has detected one or more
@@ -82,6 +85,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorTargetNamespaceMissing
           annotations:
             description: At least one CredentialsRequest custom resource has specified
@@ -101,6 +105,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-ImageRegistryOperator
       rules:
         - alert: SYN_ImageRegistryStorageReconfigured
@@ -117,6 +122,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-SamplesOperator
       rules:
         - alert: SYN_SamplesDegraded
@@ -131,6 +137,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesImagestreamImportFailing
           annotations:
             message: "Samples operator is detecting problems with imagestream image\
@@ -149,6 +156,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesInvalidConfig
           annotations:
             message: 'Samples operator has been given an invalid configuration.
@@ -160,6 +168,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesMissingSecret
           annotations:
             message: 'Samples operator cannot find the samples pull secret in the
@@ -172,6 +181,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesMissingTBRCredential
           annotations:
             message: 'The samples operator cannot find credentials for ''registry.redhat.io''.
@@ -186,6 +196,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesRetriesMissingOnImagestreamImportFailing
           annotations:
             message: "Samples operator is detecting problems with imagestream image\
@@ -206,6 +217,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesTBRInaccessibleOnBoot
           annotations:
             message: 'One of two situations has occurred.  Either
@@ -240,6 +252,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-alertmanager.rules
       rules:
         - alert: SYN_AlertmanagerClusterDown
@@ -258,6 +271,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -274,6 +288,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -288,6 +303,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerFailedReload
           annotations:
             description: Configuration has failed to load for {{ $labels.namespace
@@ -309,6 +325,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -323,6 +340,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -340,6 +358,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-apiserver-requests-in-flight
       rules: []
     - name: syn-cluster-machine-approver.rules
@@ -367,6 +386,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-network-operator-sdn.rules
       rules:
         - alert: SYN_ClusterProxyApplySlow
@@ -381,6 +401,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeProxyApplySlow
           annotations:
             summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node
@@ -396,6 +417,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeProxyApplyStale
           annotations:
             summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node
@@ -412,6 +434,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeWithoutSDNController
           annotations:
             summary: All control plane nodes should be running a sdn controller pod,
@@ -424,6 +447,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeWithoutSDNPod
           annotations:
             summary: All nodes should be running an sdn pod, {{"{{"}} $labels.node
@@ -437,6 +461,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SDNPodNotReady
           annotations:
             summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node
@@ -450,6 +475,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-operators
       rules:
         - alert: SYN_ClusterNotUpgradeable
@@ -475,6 +501,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorDegraded
           annotations:
             description: The {{ $labels.name }} operator is degraded because {{ $labels.reason
@@ -493,6 +520,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorDown
           annotations:
             description: The {{ $labels.name }} operator may be down or disabled,
@@ -511,6 +539,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorFlapping
           annotations:
             description: The  {{ $labels.name }} operator behavior might cause upgrades
@@ -528,6 +557,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-version
       rules:
         - alert: SYN_CannotRetrieveUpdates
@@ -555,6 +585,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterVersionOperatorDown
           annotations:
             description: The operator may be down or disabled. The cluster will not
@@ -574,6 +605,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeControllerManagerDown
           annotations:
             description: KubeControllerManager has disappeared from Prometheus target
@@ -589,6 +621,7 @@ spec:
             namespace: openshift-kube-controller-manager
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeSchedulerDown
           annotations:
             description: KubeScheduler has disappeared from Prometheus target discovery.
@@ -602,6 +635,7 @@ spec:
             namespace: openshift-kube-scheduler
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PodDisruptionBudgetAtLimit
           annotations:
             description: The pod disruption budget is at the minimum disruptions allowed
@@ -620,6 +654,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PodDisruptionBudgetLimit
           annotations:
             description: The pod disruption budget is below the minimum disruptions
@@ -636,6 +671,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_TechPreviewNoUpgrade
           annotations:
             description: Cluster has enabled Technology Preview features that cannot
@@ -651,6 +687,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_UpdateAvailable
           annotations:
             description: For more information refer to 'oc adm upgrade'{{ with $console_url
@@ -666,6 +703,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-config-reloaders
       rules:
         - alert: SYN_ConfigReloaderSidecarErrors
@@ -685,6 +723,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-control-plane-cpu-utilization
       rules:
         - alert: SYN_ExtremelyHighIndividualControlPlaneCPU
@@ -712,6 +751,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ExtremelyHighIndividualControlPlaneCPU
           annotations:
             description: Extreme CPU pressure can cause slow serialization and poor
@@ -737,6 +777,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_HighOverallControlPlaneCPU
           annotations:
             description: Given three control plane nodes, the overall CPU utilization
@@ -760,6 +801,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-etcd
       rules:
         - alert: SYN_etcdDatabaseHighFragmentationRatio
@@ -780,6 +822,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdDatabaseQuotaLowSpace
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": database size exceeds
@@ -797,6 +840,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdExcessiveDatabaseGrowth
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": Predicting running out
@@ -812,6 +856,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighCommitDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit
@@ -827,6 +872,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighFsyncDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
@@ -842,6 +888,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighFsyncDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
@@ -858,6 +905,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedProposals
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }} proposal
@@ -873,6 +921,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdMemberCommunicationSlow
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": member communication with
@@ -889,6 +938,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdMembersDown
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value
@@ -903,6 +953,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdNoLeader
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": member {{ $labels.instance
@@ -917,6 +968,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-general.rules
       rules:
         - alert: Watchdog
@@ -944,6 +996,7 @@ spec:
             namespace: openshift-monitoring
             severity: none
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-k8s.rules
       rules: []
     - name: syn-kube-apiserver-slos-basic
@@ -972,6 +1025,7 @@ spec:
             severity: critical
             short: 5m
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget. This alert
@@ -996,6 +1050,7 @@ spec:
             severity: critical
             short: 30m
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kube-apiserver.rules
       rules: []
     - name: syn-kube-prometheus-general.rules
@@ -1020,6 +1075,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -1034,6 +1090,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubelet.rules
       rules: []
     - name: syn-kubernetes-apps
@@ -1053,6 +1110,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -1067,6 +1125,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -1080,6 +1139,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -1104,6 +1164,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -1118,6 +1179,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeHpaMaxedOut
           annotations:
             description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
@@ -1131,6 +1193,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeHpaReplicasMismatch
           annotations:
             description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
@@ -1153,6 +1216,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeJobCompletion
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -1168,6 +1232,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -1184,6 +1249,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePodCrashLooping
           annotations:
             description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
@@ -1199,6 +1265,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -1215,6 +1282,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1229,6 +1297,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1245,6 +1314,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1264,6 +1334,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-recurring.rules
       rules: []
     - name: syn-kubernetes-resources
@@ -1288,6 +1359,7 @@ spec:
             namespace: kube-system
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeCPUQuotaOvercommit
           annotations:
             description: Cluster has overcommitted CPU resource requests for Namespaces.
@@ -1301,6 +1373,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeMemoryOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Pods
@@ -1322,6 +1395,7 @@ spec:
             namespace: kube-system
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Namespaces.
@@ -1335,6 +1409,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1349,6 +1424,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1363,6 +1439,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1377,6 +1454,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-storage
       rules:
         - alert: SYN_KubePersistentVolumeErrors
@@ -1393,6 +1471,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -1415,6 +1494,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -1440,6 +1520,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system
       rules:
         - alert: SYN_KubeClientErrors
@@ -1455,6 +1536,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system-apiserver
       rules:
         - alert: SYN_KubeAPIDown
@@ -1470,6 +1552,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -1486,6 +1569,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -1500,6 +1584,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -1514,6 +1599,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system-kubelet
       rules:
         - alert: SYN_KubeNodeNotReady
@@ -1530,6 +1616,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -1544,6 +1631,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -1559,6 +1647,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -1573,6 +1662,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -1587,6 +1677,7 @@ spec:
             namespace: kube-system
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -1601,6 +1692,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -1616,6 +1708,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -1629,6 +1722,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -1644,6 +1738,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-api-operator-metrics-collector-up
       rules:
         - alert: SYN_MachineAPIOperatorMetricsCollectionFailing
@@ -1659,6 +1754,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-health-check-unterminated-short-circuit
       rules:
         - alert: SYN_MachineHealthCheckUnterminatedShortCircuit
@@ -1679,6 +1775,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-not-yet-deleted
       rules:
         - alert: SYN_MachineNotYetDeleted
@@ -1703,6 +1800,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-with-no-running-phase
       rules:
         - alert: SYN_MachineWithNoRunningPhase
@@ -1726,6 +1824,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-without-valid-node-ref
       rules:
         - alert: SYN_MachineWithoutValidNode
@@ -1747,6 +1846,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-master-nodes-high-memory-usage
       rules:
         - alert: SYN_MasterNodesHighMemoryUsage
@@ -1768,6 +1868,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-drain-error
       rules:
         - alert: SYN_MCDDrainError
@@ -1782,6 +1883,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-kubelet-health-state-error
       rules:
         - alert: SYN_KubeletHealthState
@@ -1794,6 +1896,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-pivot-error
       rules:
         - alert: SYN_MCDPivotError
@@ -1806,6 +1909,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-reboot-error
       rules:
         - alert: SYN_MCDRebootError
@@ -1818,6 +1922,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-exporter
       rules:
         - alert: SYN_NodeClockNotSynchronising
@@ -1837,6 +1942,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeClockSkewDetected
           annotations:
             description: Clock on {{ $labels.instance }} is out of sync by more than
@@ -1850,6 +1956,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -1863,6 +1970,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -1876,6 +1984,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1891,6 +2000,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1906,6 +2016,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1921,6 +2032,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1936,6 +2048,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1954,6 +2067,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1972,6 +2086,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1990,6 +2105,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2008,6 +2124,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $value | humanizePercentage }} of conntrack entries are
@@ -2020,6 +2137,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -2035,6 +2153,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -2050,6 +2169,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' on {{ $labels.instance
@@ -2066,6 +2186,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array on {{ $labels.instance
@@ -2079,6 +2200,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector failed to scrape.
@@ -2090,6 +2212,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-exporter.rules
       rules: []
     - name: syn-node-network
@@ -2109,6 +2232,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-utilization
       rules:
         - alert: SYN_node_cpu_load5
@@ -2122,6 +2246,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_node_memory_free_percent
           annotations:
             message: '{{ $labels.node }}: Memory usage more than 97% (current value
@@ -2133,6 +2258,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node.rules
       rules: []
     - name: syn-olm.failing_operators.rules
@@ -2146,6 +2272,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-build.rules
       rules: []
     - name: syn-openshift-etcd-telemetry.rules
@@ -2170,6 +2297,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedGRPCRequests
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
@@ -2185,6 +2313,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedGRPCRequests
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
@@ -2201,6 +2330,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfLeaderChanges
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }} average leader
@@ -2216,6 +2346,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdInsufficientMembers
           annotations:
             description: etcd is reporting fewer instances are available than are
@@ -2236,6 +2367,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-general.rules
       rules:
         - alert: SYN_TargetDown
@@ -2257,6 +2389,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-ingress.rules
       rules:
         - alert: SYN_HAProxyDown
@@ -2271,6 +2404,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_HAProxyReloadFail
           annotations:
             description: This alert fires when HAProxy fails to reload its configuration,
@@ -2285,6 +2419,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_IngressControllerDegraded
           annotations:
             description: This alert fires when the IngressController status is degraded.
@@ -2301,6 +2436,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_IngressControllerUnavailable
           annotations:
             description: This alert fires when the IngressController is not available.
@@ -2317,6 +2453,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-kubernetes.rules
       rules:
         - alert: SYN_AlertmanagerReceiversNotConfigured
@@ -2333,6 +2470,7 @@ spec:
             namespace: openshift-monitoring
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterMonitoringOperatorReconciliationErrors
           annotations:
             description: Errors are occurring during reconciliation cycles. Inspect
@@ -2346,6 +2484,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -2370,6 +2509,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_MultipleContainersOOMKilled
           annotations:
             description: Multiple containers were out of memory killed within the
@@ -2385,6 +2525,7 @@ spec:
             namespace: kube-system
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-monitoring.rules
       rules: []
     - name: syn-openshift-sre.rules
@@ -2412,6 +2553,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_APIRemovedInNextReleaseInUse
           annotations:
             description: Deprecated API that will be removed in the next version is
@@ -2433,6 +2575,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-prometheus
       rules:
         - alert: SYN_PrometheusBadConfig
@@ -2455,6 +2598,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -2470,6 +2614,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -2485,6 +2630,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -2501,6 +2647,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -2516,6 +2663,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -2536,6 +2684,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -2551,6 +2700,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -2567,6 +2717,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -2582,6 +2733,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -2600,6 +2752,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -2617,6 +2770,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -2636,6 +2790,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -2650,6 +2805,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -2664,6 +2820,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -2678,6 +2835,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -2694,6 +2852,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -2709,6 +2868,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-prometheus-operator
       rules:
         - alert: SYN_PrometheusOperatorListErrors
@@ -2728,6 +2888,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -2743,6 +2904,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -2758,6 +2920,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -2776,6 +2939,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -2792,6 +2956,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -2807,6 +2972,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -2824,6 +2990,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-scheduler-legacy-policy-deprecated
       rules:
         - alert: SYN_SchedulerLegacyPolicySet
@@ -2839,6 +3006,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-system-memory-exceeds-reservation
       rules:
         - alert: SYN_SystemMemoryExceedsReservation
@@ -2861,6 +3029,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-thanos-query
       rules:
         - alert: SYN_ThanosQueryGrpcClientErrorRate
@@ -2876,6 +3045,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryGrpcServerErrorRate
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
@@ -2890,6 +3060,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHighDNSFailures
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} have
@@ -2903,6 +3074,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHttpRequestQueryErrorRateHigh
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
@@ -2917,6 +3089,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHttpRequestQueryRangeErrorRateHigh
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
@@ -2931,6 +3104,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-thanos-rule
       rules:
         - alert: SYN_ThanosNoRuleEvaluations
@@ -2946,6 +3120,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleAlertmanagerHighDNSFailures
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -2959,6 +3134,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleConfigReloadFailure
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
@@ -2971,6 +3147,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleGrpcErrorRate
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} is failing
@@ -2986,6 +3163,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleHighRuleEvaluationFailures
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -2999,6 +3177,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleHighRuleEvaluationWarnings
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3013,6 +3192,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleNoEvaluationFor10Intervals
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
@@ -3031,6 +3211,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleQueryHighDNSFailures
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
@@ -3044,6 +3225,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleQueueIsDroppingAlerts
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3059,6 +3241,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleRuleEvaluationLatencyHigh
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3073,6 +3256,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleSenderIsFailingAlerts
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3087,3 +3271,4 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -26,6 +26,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorInsufficientCloudCreds
           annotations:
             description: The Cloud Credential Operator has determined that there are
@@ -42,6 +43,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorProvisioningFailed
           annotations:
             description: While processing a CredentialsRequest, the Cloud Credential
@@ -58,6 +60,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorStaleCredentials
           annotations:
             description: The Cloud Credential Operator (CCO) has detected one or more
@@ -82,6 +85,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorTargetNamespaceMissing
           annotations:
             description: At least one CredentialsRequest custom resource has specified
@@ -101,6 +105,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-SamplesOperator
       rules:
         - alert: SYN_SamplesDegraded
@@ -116,6 +121,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesImagestreamImportFailing
           annotations:
             description: "Samples operator is detecting problems with imagestream\
@@ -137,6 +143,7 @@ spec:
             namespace: openshift-cluster-samples-operator
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesInvalidConfig
           annotations:
             description: 'Samples operator has been given an invalid configuration.
@@ -149,6 +156,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesMissingSecret
           annotations:
             description: 'Samples operator cannot find the samples pull secret in
@@ -162,6 +170,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesMissingTBRCredential
           annotations:
             description: 'The samples operator cannot find credentials for ''registry.redhat.io''.
@@ -177,6 +186,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesRetriesMissingOnImagestreamImportFailing
           annotations:
             description: "Samples operator is detecting problems with imagestream\
@@ -200,6 +210,7 @@ spec:
             namespace: openshift-cluster-samples-operator
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesTBRInaccessibleOnBoot
           annotations:
             description: 'One of two situations has occurred.  Either
@@ -237,6 +248,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-alertmanager.rules
       rules:
         - alert: SYN_AlertmanagerClusterDown
@@ -255,6 +267,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -272,6 +285,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -286,6 +300,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerFailedReload
           annotations:
             description: Configuration has failed to load for {{ $labels.namespace
@@ -307,6 +322,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -322,6 +338,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -339,6 +356,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-apiserver-requests-in-flight
       rules: []
     - name: syn-cluster-machine-approver.rules
@@ -366,6 +384,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-network-operator-sdn.rules
       rules:
         - alert: SYN_ClusterProxyApplySlow
@@ -383,6 +402,7 @@ spec:
             namespace: openshift-sdn
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeProxyApplySlow
           annotations:
             description: Configuration of proxy rules for Kubernetes services in the
@@ -399,6 +419,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeProxyApplyStale
           annotations:
             description: Stale proxy rules for Kubernetes services may increase the
@@ -417,6 +438,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeWithoutSDNController
           annotations:
             description: 'If at least one OpenShift SDN controller is ''Running'',
@@ -435,6 +457,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeWithoutSDNPod
           annotations:
             description: Network control plane configuration on the node could be
@@ -450,6 +473,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SDNPodNotReady
           annotations:
             description: Network control plane configuration on the node could be
@@ -465,6 +489,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-operators
       rules:
         - alert: SYN_ClusterNotUpgradeable
@@ -490,6 +515,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorDegraded
           annotations:
             description: The {{ $labels.name }} operator is degraded because {{ $labels.reason
@@ -508,6 +534,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorDown
           annotations:
             description: The {{ $labels.name }} operator may be down or disabled,
@@ -526,6 +553,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorFlapping
           annotations:
             description: The  {{ $labels.name }} operator behavior might cause upgrades
@@ -543,6 +571,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-version
       rules:
         - alert: SYN_CannotRetrieveUpdates
@@ -570,6 +599,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterVersionOperatorDown
           annotations:
             description: The operator may be down or disabled. The cluster will not
@@ -589,6 +619,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_GarbageCollectorSyncFailed
           annotations:
             description: Garbage Collector had a problem with syncing and monitoring
@@ -605,6 +636,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeControllerManagerDown
           annotations:
             description: KubeControllerManager has disappeared from Prometheus target
@@ -620,6 +652,7 @@ spec:
             namespace: openshift-kube-controller-manager
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeSchedulerDown
           annotations:
             description: KubeScheduler has disappeared from Prometheus target discovery.
@@ -633,6 +666,7 @@ spec:
             namespace: openshift-kube-scheduler
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PodDisruptionBudgetAtLimit
           annotations:
             description: The pod disruption budget is at the minimum disruptions allowed
@@ -651,6 +685,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PodDisruptionBudgetLimit
           annotations:
             description: The pod disruption budget is below the minimum disruptions
@@ -667,6 +702,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_TechPreviewNoUpgrade
           annotations:
             description: Cluster has enabled Technology Preview features that cannot
@@ -682,6 +718,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_UpdateAvailable
           annotations:
             description: For more information refer to 'oc adm upgrade'{{ with $console_url
@@ -697,6 +734,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-config-reloaders
       rules:
         - alert: SYN_ConfigReloaderSidecarErrors
@@ -716,6 +754,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-control-plane-cpu-utilization
       rules:
         - alert: SYN_ExtremelyHighIndividualControlPlaneCPU
@@ -743,6 +782,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ExtremelyHighIndividualControlPlaneCPU
           annotations:
             description: Extreme CPU pressure can cause slow serialization and poor
@@ -768,6 +808,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_HighOverallControlPlaneCPU
           annotations:
             description: Given three control plane nodes, the overall CPU utilization
@@ -791,6 +832,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-etcd
       rules:
         - alert: SYN_etcdDatabaseHighFragmentationRatio
@@ -811,6 +853,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdDatabaseQuotaLowSpace
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": database size exceeds
@@ -828,6 +871,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdExcessiveDatabaseGrowth
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": Predicting running out
@@ -843,6 +887,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighCommitDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit
@@ -858,6 +903,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighFsyncDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
@@ -873,6 +919,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighFsyncDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
@@ -889,6 +936,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedProposals
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }} proposal
@@ -904,6 +952,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdMemberCommunicationSlow
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": member communication with
@@ -920,6 +969,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdMembersDown
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value
@@ -934,6 +984,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdNoLeader
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": member {{ $labels.instance
@@ -948,6 +999,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-extremely-high-individual-control-plane-memory
       rules:
         - alert: SYN_ExtremelyHighIndividualControlPlaneMemory
@@ -974,6 +1026,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-general.rules
       rules:
         - alert: Watchdog
@@ -1001,6 +1054,7 @@ spec:
             namespace: openshift-monitoring
             severity: none
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-high-overall-control-plane-memory
       rules:
         - alert: SYN_HighOverallControlPlaneMemory
@@ -1039,6 +1093,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-k8s.rules
       rules: []
     - name: syn-kube-apiserver-slos-basic
@@ -1067,6 +1122,7 @@ spec:
             severity: critical
             short: 5m
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget. This alert
@@ -1091,6 +1147,7 @@ spec:
             severity: critical
             short: 30m
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kube-apiserver.rules
       rules: []
     - name: syn-kube-prometheus-general.rules
@@ -1115,6 +1172,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -1129,6 +1187,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubelet.rules
       rules: []
     - name: syn-kubernetes-apps
@@ -1148,6 +1207,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -1162,6 +1222,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -1175,6 +1236,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -1199,6 +1261,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -1213,6 +1276,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeHpaMaxedOut
           annotations:
             description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
@@ -1226,6 +1290,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeHpaReplicasMismatch
           annotations:
             description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
@@ -1248,6 +1313,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -1264,6 +1330,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeJobNotCompleted
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -1277,6 +1344,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePodCrashLooping
           annotations:
             description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
@@ -1292,6 +1360,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -1309,6 +1378,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1323,6 +1393,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1339,6 +1410,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1358,6 +1430,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-recurring.rules
       rules: []
     - name: syn-kubernetes-resources
@@ -1382,6 +1455,7 @@ spec:
             namespace: kube-system
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeCPUQuotaOvercommit
           annotations:
             description: Cluster has overcommitted CPU resource requests for Namespaces.
@@ -1395,6 +1469,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeMemoryOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Pods
@@ -1416,6 +1491,7 @@ spec:
             namespace: kube-system
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Namespaces.
@@ -1429,6 +1505,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1443,6 +1520,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1457,6 +1535,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1471,6 +1550,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-storage
       rules:
         - alert: SYN_KubePersistentVolumeErrors
@@ -1487,6 +1567,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -1509,6 +1590,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -1534,6 +1616,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeInodesFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -1556,6 +1639,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeInodesFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -1581,6 +1665,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system
       rules:
         - alert: SYN_KubeClientErrors
@@ -1596,6 +1681,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system-apiserver
       rules:
         - alert: SYN_KubeAPIDown
@@ -1611,6 +1697,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -1627,6 +1714,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -1641,6 +1729,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -1655,6 +1744,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system-kubelet
       rules:
         - alert: SYN_KubeNodeNotReady
@@ -1671,6 +1761,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -1685,6 +1776,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -1700,6 +1792,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -1714,6 +1807,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -1728,6 +1822,7 @@ spec:
             namespace: kube-system
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -1742,6 +1837,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -1758,6 +1854,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -1771,6 +1868,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -1786,6 +1884,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-api-operator-metrics-collector-up
       rules:
         - alert: SYN_MachineAPIOperatorMetricsCollectionFailing
@@ -1801,6 +1900,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-health-check-unterminated-short-circuit
       rules:
         - alert: SYN_MachineHealthCheckUnterminatedShortCircuit
@@ -1821,6 +1921,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-not-yet-deleted
       rules:
         - alert: SYN_MachineNotYetDeleted
@@ -1845,6 +1946,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-with-no-running-phase
       rules:
         - alert: SYN_MachineWithNoRunningPhase
@@ -1868,6 +1970,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-without-valid-node-ref
       rules:
         - alert: SYN_MachineWithoutValidNode
@@ -1889,6 +1992,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcc-paused-pool-kubelet-ca
       rules:
         - alert: SYN_MachineConfigControllerPausedPoolKubeletCA
@@ -1919,6 +2023,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_MachineConfigControllerPausedPoolKubeletCA
           annotations:
             description: Machine config pools have a 'pause' feature, which allows
@@ -1949,6 +2054,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-drain-error
       rules:
         - alert: SYN_MCDDrainError
@@ -1963,6 +2069,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-kubelet-health-state-error
       rules:
         - alert: SYN_KubeletHealthState
@@ -1975,6 +2082,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-pivot-error
       rules:
         - alert: SYN_MCDPivotError
@@ -1987,6 +2095,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-reboot-error
       rules:
         - alert: SYN_MCDRebootError
@@ -1999,6 +2108,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-exporter
       rules:
         - alert: SYN_NodeClockNotSynchronising
@@ -2019,6 +2129,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeClockSkewDetected
           annotations:
             description: Clock on {{ $labels.instance }} is out of sync by more than
@@ -2032,6 +2143,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -2045,6 +2157,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -2058,6 +2171,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2073,6 +2187,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2088,6 +2203,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2103,6 +2219,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2118,6 +2235,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2136,6 +2254,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2154,6 +2273,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2172,6 +2292,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2190,6 +2311,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $value | humanizePercentage }} of conntrack entries are
@@ -2202,6 +2324,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -2217,6 +2340,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -2232,6 +2356,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' on {{ $labels.instance
@@ -2248,6 +2373,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array on {{ $labels.instance
@@ -2261,6 +2387,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector failed to scrape.
@@ -2272,6 +2399,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-exporter.rules
       rules: []
     - name: syn-node-network
@@ -2291,6 +2419,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-utilization
       rules:
         - alert: SYN_node_cpu_load5
@@ -2304,6 +2433,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_node_memory_free_percent
           annotations:
             message: '{{ $labels.node }}: Memory usage more than 97% (current value
@@ -2315,6 +2445,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node.rules
       rules: []
     - name: syn-olm.failing_operators.rules
@@ -2328,6 +2459,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-build.rules
       rules: []
     - name: syn-openshift-etcd-telemetry.rules
@@ -2352,6 +2484,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedGRPCRequests
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
@@ -2367,6 +2500,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedGRPCRequests
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
@@ -2383,6 +2517,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfLeaderChanges
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }} average leader
@@ -2398,6 +2533,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdInsufficientMembers
           annotations:
             description: etcd is reporting fewer instances are available than are
@@ -2418,6 +2554,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-general.rules
       rules:
         - alert: SYN_TargetDown
@@ -2439,6 +2576,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-ingress.rules
       rules:
         - alert: SYN_HAProxyDown
@@ -2453,6 +2591,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_HAProxyReloadFail
           annotations:
             description: This alert fires when HAProxy fails to reload its configuration,
@@ -2467,6 +2606,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_IngressControllerDegraded
           annotations:
             description: This alert fires when the IngressController status is degraded.
@@ -2483,6 +2623,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_IngressControllerUnavailable
           annotations:
             description: This alert fires when the IngressController is not available.
@@ -2499,6 +2640,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-kubernetes.rules
       rules:
         - alert: SYN_AlertmanagerReceiversNotConfigured
@@ -2515,6 +2657,7 @@ spec:
             namespace: openshift-monitoring
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterMonitoringOperatorReconciliationErrors
           annotations:
             description: Errors are occurring during reconciliation cycles. Inspect
@@ -2528,6 +2671,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -2552,6 +2696,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_MultipleContainersOOMKilled
           annotations:
             description: Multiple containers were out of memory killed within the
@@ -2567,6 +2712,7 @@ spec:
             namespace: kube-system
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-monitoring.rules
       rules: []
     - name: syn-openshift-sre.rules
@@ -2594,6 +2740,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_APIRemovedInNextReleaseInUse
           annotations:
             description: Deprecated API that will be removed in the next version is
@@ -2615,6 +2762,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-prometheus
       rules:
         - alert: SYN_PrometheusBadConfig
@@ -2637,6 +2785,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -2652,6 +2801,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -2667,6 +2817,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -2683,6 +2834,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -2698,6 +2850,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -2718,6 +2871,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -2733,6 +2887,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -2749,6 +2904,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -2764,6 +2920,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -2782,6 +2939,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -2799,6 +2957,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -2818,6 +2977,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -2832,6 +2992,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusScrapeBodySizeLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -2847,6 +3008,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusScrapeSampleLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -2863,6 +3025,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -2877,6 +3040,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -2891,6 +3055,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -2907,6 +3072,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -2922,6 +3088,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-prometheus-operator
       rules:
         - alert: SYN_PrometheusOperatorListErrors
@@ -2941,6 +3108,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -2956,6 +3124,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -2971,6 +3140,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -2989,6 +3159,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -3005,6 +3176,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -3020,6 +3192,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -3037,6 +3210,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-scheduler-legacy-policy-deprecated
       rules:
         - alert: SYN_SchedulerLegacyPolicySet
@@ -3052,6 +3226,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-system-memory-exceeds-reservation
       rules:
         - alert: SYN_SystemMemoryExceedsReservation
@@ -3074,6 +3249,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-thanos-query
       rules:
         - alert: SYN_ThanosQueryGrpcClientErrorRate
@@ -3089,6 +3265,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryGrpcServerErrorRate
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
@@ -3103,6 +3280,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHighDNSFailures
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} have
@@ -3116,6 +3294,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHttpRequestQueryErrorRateHigh
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
@@ -3130,6 +3309,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHttpRequestQueryRangeErrorRateHigh
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
@@ -3144,6 +3324,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-thanos-rule
       rules:
         - alert: SYN_ThanosNoRuleEvaluations
@@ -3159,6 +3340,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleAlertmanagerHighDNSFailures
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3172,6 +3354,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleConfigReloadFailure
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
@@ -3184,6 +3367,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleGrpcErrorRate
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} is failing
@@ -3199,6 +3383,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleHighRuleEvaluationFailures
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3212,6 +3397,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleHighRuleEvaluationWarnings
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3226,6 +3412,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleNoEvaluationFor10Intervals
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
@@ -3244,6 +3431,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleQueryHighDNSFailures
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
@@ -3257,6 +3445,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleQueueIsDroppingAlerts
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3272,6 +3461,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleRuleEvaluationLatencyHigh
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3286,6 +3476,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleSenderIsFailingAlerts
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3300,3 +3491,4 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -26,6 +26,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorInsufficientCloudCreds
           annotations:
             description: The Cloud Credential Operator has determined that there are
@@ -42,6 +43,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorProvisioningFailed
           annotations:
             description: While processing a CredentialsRequest, the Cloud Credential
@@ -58,6 +60,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorStaleCredentials
           annotations:
             message: 1 or more credentials requests are stale and should be deleted.
@@ -70,6 +73,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorTargetNamespaceMissing
           annotations:
             description: At least one CredentialsRequest custom resource has specified
@@ -89,6 +93,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-ImageRegistryOperator
       rules:
         - alert: SYN_ImageRegistryStorageReconfigured
@@ -105,6 +110,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-SamplesOperator
       rules:
         - alert: SYN_SamplesDegraded
@@ -119,6 +125,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesImagestreamImportFailing
           annotations:
             message: "Samples operator is detecting problems with imagestream image\
@@ -137,6 +144,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesInvalidConfig
           annotations:
             message: 'Samples operator has been given an invalid configuration.
@@ -148,6 +156,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesMissingSecret
           annotations:
             message: 'Samples operator cannot find the samples pull secret in the
@@ -160,6 +169,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesMissingTBRCredential
           annotations:
             message: 'The samples operator cannot find credentials for ''registry.redhat.io''.
@@ -174,6 +184,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesRetriesMissingOnImagestreamImportFailing
           annotations:
             message: "Samples operator is detecting problems with imagestream image\
@@ -194,6 +205,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesTBRInaccessibleOnBoot
           annotations:
             message: 'One of two situations has occurred.  Either
@@ -228,6 +240,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-alertmanager.rules
       rules:
         - alert: SYN_AlertmanagerClusterDown
@@ -246,6 +259,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -262,6 +276,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -278,6 +293,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -292,6 +308,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerFailedReload
           annotations:
             description: Configuration has failed to load for {{ $labels.namespace
@@ -313,6 +330,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -327,6 +345,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -344,6 +363,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-apiserver-requests-in-flight
       rules: []
     - name: syn-cluster-machine-approver.rules
@@ -359,6 +379,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-network-operator-sdn.rules
       rules:
         - alert: SYN_ClusterProxyApplySlow
@@ -373,6 +394,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeProxyApplySlow
           annotations:
             summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node
@@ -385,6 +407,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeProxyApplyStale
           annotations:
             summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node
@@ -401,6 +424,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeWithoutSDNPod
           annotations:
             summary: All nodes should be running an sdn pod, {{"{{"}} $labels.node
@@ -414,6 +438,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SDNPodNotReady
           annotations:
             summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node
@@ -427,6 +452,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-operators
       rules:
         - alert: SYN_ClusterNotUpgradeable
@@ -452,6 +478,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorDegraded
           annotations:
             description: The {{ $labels.name }} operator is degraded because {{ $labels.reason
@@ -470,6 +497,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorDown
           annotations:
             description: The {{ $labels.name }} operator may be down or disabled,
@@ -488,6 +516,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorFlapping
           annotations:
             description: The  {{ $labels.name }} operator behavior might cause upgrades
@@ -505,6 +534,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-version
       rules:
         - alert: SYN_CannotRetrieveUpdates
@@ -532,6 +562,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterVersionOperatorDown
           annotations:
             description: The operator may be down or disabled. The cluster will not
@@ -551,6 +582,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeControllerManagerDown
           annotations:
             message: KubeControllerManager has disappeared from Prometheus target
@@ -563,6 +595,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeSchedulerDown
           annotations:
             message: KubeScheduler has disappeared from Prometheus target discovery.
@@ -574,6 +607,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PodDisruptionBudgetAtLimit
           annotations:
             message: The pod disruption budget is preventing further disruption to
@@ -587,6 +621,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PodDisruptionBudgetLimit
           annotations:
             message: The pod disruption budget is below the minimum number allowed
@@ -600,6 +635,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_TechPreviewNoUpgrade
           annotations:
             message: Cluster has enabled tech preview features that will prevent upgrades.
@@ -612,6 +648,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_UpdateAvailable
           annotations:
             description: For more information refer to 'oc adm upgrade'{{ with $console_url
@@ -627,6 +664,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-control-plane-cpu-utilization
       rules:
         - alert: SYN_ExtremelyHighIndividualControlPlaneCPU
@@ -653,6 +691,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_HighOverallControlPlaneCPU
           annotations:
             message: Given three control plane nodes, the overall CPU utilization
@@ -675,6 +714,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-etcd
       rules:
         - alert: SYN_etcdDatabaseHighFragmentationRatio
@@ -695,6 +735,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdDatabaseQuotaLowSpace
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": database size exceeds
@@ -712,6 +753,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdExcessiveDatabaseGrowth
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": Predicting running out
@@ -727,6 +769,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdGRPCRequestsSlow
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile of gRPC
@@ -745,6 +788,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighCommitDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit
@@ -760,6 +804,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighFsyncDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
@@ -775,6 +820,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighFsyncDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
@@ -791,6 +837,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedProposals
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }} proposal
@@ -806,6 +853,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdMemberCommunicationSlow
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": member communication with
@@ -822,6 +870,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdMembersDown
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value
@@ -836,6 +885,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdNoLeader
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": member {{ $labels.instance
@@ -850,6 +900,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-general.rules
       rules:
         - alert: Watchdog
@@ -877,6 +928,7 @@ spec:
             namespace: openshift-monitoring
             severity: none
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-k8s.rules
       rules: []
     - name: syn-kube-apiserver-slos-basic
@@ -904,6 +956,7 @@ spec:
             severity: critical
             short: 5m
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget. This alert
@@ -927,6 +980,7 @@ spec:
             severity: critical
             short: 30m
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kube-apiserver.rules
       rules: []
     - name: syn-kube-prometheus-general.rules
@@ -951,6 +1005,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -965,6 +1020,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubelet.rules
       rules: []
     - name: syn-kubernetes-apps
@@ -983,6 +1039,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -997,6 +1054,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -1010,6 +1068,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -1034,6 +1093,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -1048,6 +1108,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeHpaMaxedOut
           annotations:
             description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
@@ -1061,6 +1122,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeHpaReplicasMismatch
           annotations:
             description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
@@ -1083,6 +1145,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeJobCompletion
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -1098,6 +1161,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -1114,6 +1178,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePodCrashLooping
           annotations:
             description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
@@ -1129,6 +1194,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -1145,6 +1211,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1159,6 +1226,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1175,6 +1243,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1194,6 +1263,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-recurring.rules
       rules: []
     - name: syn-kubernetes-resources
@@ -1218,6 +1288,7 @@ spec:
             namespace: kube-system
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeCPUQuotaOvercommit
           annotations:
             description: Cluster has overcommitted CPU resource requests for Namespaces.
@@ -1230,6 +1301,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeMemoryOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Pods
@@ -1251,6 +1323,7 @@ spec:
             namespace: kube-system
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Namespaces.
@@ -1264,6 +1337,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1278,6 +1352,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1292,6 +1367,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1306,6 +1382,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-storage
       rules:
         - alert: SYN_KubePersistentVolumeErrors
@@ -1322,6 +1399,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -1339,6 +1417,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -1359,6 +1438,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system
       rules:
         - alert: SYN_KubeClientErrors
@@ -1374,6 +1454,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system-apiserver
       rules:
         - alert: SYN_AggregatedAPIDown
@@ -1390,6 +1471,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AggregatedAPIErrors
           annotations:
             description: An aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -1404,6 +1486,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPIDown
           annotations:
             description: KubeAPI has disappeared from Prometheus target discovery.
@@ -1417,6 +1500,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPITerminatedRequests
           annotations:
             description: The apiserver has terminated {{ $value | humanizePercentage
@@ -1433,6 +1517,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system-kubelet
       rules:
         - alert: SYN_KubeNodeNotReady
@@ -1449,6 +1534,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -1463,6 +1549,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -1478,6 +1565,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -1492,6 +1580,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -1506,6 +1595,7 @@ spec:
             namespace: kube-system
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -1520,6 +1610,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -1535,6 +1626,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -1548,6 +1640,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -1563,6 +1656,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-api-operator-metrics-collector-up
       rules:
         - alert: SYN_MachineAPIOperatorMetricsCollectionFailing
@@ -1578,6 +1672,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-health-check-unterminated-short-circuit
       rules:
         - alert: SYN_MachineHealthCheckUnterminatedShortCircuit
@@ -1598,6 +1693,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-not-yet-deleted
       rules:
         - alert: SYN_MachineNotYetDeleted
@@ -1622,6 +1718,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-with-no-running-phase
       rules:
         - alert: SYN_MachineWithNoRunningPhase
@@ -1645,6 +1742,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-without-valid-node-ref
       rules:
         - alert: SYN_MachineWithoutValidNode
@@ -1666,6 +1764,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-master-nodes-high-memory-usage
       rules:
         - alert: SYN_MasterNodesHighMemoryUsage
@@ -1687,6 +1786,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-drain-error
       rules:
         - alert: SYN_MCDDrainError
@@ -1701,6 +1801,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-kubelet-health-state-error
       rules:
         - alert: SYN_KubeletHealthState
@@ -1713,6 +1814,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-pivot-error
       rules:
         - alert: SYN_MCDPivotError
@@ -1725,6 +1827,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-reboot-error
       rules:
         - alert: SYN_MCDRebootError
@@ -1737,6 +1840,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-exporter
       rules:
         - alert: SYN_NodeClockNotSynchronising
@@ -1756,6 +1860,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeClockSkewDetected
           annotations:
             description: Clock on {{ $labels.instance }} is out of sync by more than
@@ -1769,6 +1874,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -1782,6 +1888,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -1795,6 +1902,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1810,6 +1918,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1825,6 +1934,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1840,6 +1950,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1855,6 +1966,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1873,6 +1985,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1891,6 +2004,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1909,6 +2023,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1927,6 +2042,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $value | humanizePercentage }} of conntrack entries are
@@ -1939,6 +2055,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -1954,6 +2071,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -1969,6 +2087,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' on {{ $labels.instance
@@ -1985,6 +2104,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array on {{ $labels.instance
@@ -1998,6 +2118,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector failed to scrape.
@@ -2009,6 +2130,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-exporter.rules
       rules: []
     - name: syn-node-network
@@ -2028,6 +2150,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-utilization
       rules:
         - alert: SYN_node_cpu_load5
@@ -2041,6 +2164,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_node_memory_free_percent
           annotations:
             message: '{{ $labels.node }}: Memory usage more than 97% (current value
@@ -2052,6 +2176,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node.rules
       rules: []
     - name: syn-olm.failing_operators.rules
@@ -2065,6 +2190,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-build.rules
       rules: []
     - name: syn-openshift-etcd-telemetry.rules
@@ -2088,6 +2214,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdInsufficientMembers
           annotations:
             description: etcd is reporting fewer instances are available than are
@@ -2108,6 +2235,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-general.rules
       rules:
         - alert: SYN_HighlyAvailableWorkloadIncorrectlySpread
@@ -2133,6 +2261,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_TargetDown
           annotations:
             description: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{
@@ -2152,6 +2281,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-ingress.rules
       rules:
         - alert: SYN_HAProxyDown
@@ -2164,6 +2294,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_HAProxyReloadFail
           annotations:
             message: HAProxy reloads are failing on {{ $labels.pod }}. Router is not
@@ -2174,6 +2305,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_IngressControllerDegraded
           annotations:
             message: 'The {{ $labels.namespace }}/{{ $labels.name }} ingresscontroller
@@ -2188,6 +2320,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_IngressControllerUnavailable
           annotations:
             message: 'The {{ $labels.namespace }}/{{ $labels.name }} ingresscontroller
@@ -2202,6 +2335,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-kubernetes.rules
       rules:
         - alert: SYN_AlertmanagerReceiversNotConfigured
@@ -2218,6 +2352,7 @@ spec:
             namespace: openshift-monitoring
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterMonitoringOperatorReconciliationErrors
           annotations:
             description: Errors are occurring during reconciliation cycles. Inspect
@@ -2231,6 +2366,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -2255,6 +2391,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_MultipleContainersOOMKilled
           annotations:
             description: Multiple containers were out of memory killed within the
@@ -2270,6 +2407,7 @@ spec:
             namespace: kube-system
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-monitoring.rules
       rules: []
     - name: syn-openshift-sre.rules
@@ -2295,6 +2433,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_APIRemovedInNextReleaseInUse
           annotations:
             message: Deprecated API that will be removed in the next version is being
@@ -2314,6 +2453,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-prometheus
       rules:
         - alert: SYN_PrometheusBadConfig
@@ -2336,6 +2476,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -2351,6 +2492,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -2366,6 +2508,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -2382,6 +2525,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -2397,6 +2541,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -2417,6 +2562,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -2432,6 +2578,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -2448,6 +2595,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -2463,6 +2611,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -2481,6 +2630,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -2498,6 +2648,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -2517,6 +2668,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -2531,6 +2683,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -2545,6 +2698,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -2559,6 +2713,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -2575,6 +2730,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -2590,6 +2746,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-prometheus-operator
       rules:
         - alert: SYN_PrometheusOperatorListErrors
@@ -2607,6 +2764,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -2621,6 +2779,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -2635,6 +2794,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -2651,6 +2811,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -2666,6 +2827,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -2680,6 +2842,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -2695,6 +2858,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-scheduler-legacy-policy-deprecated
       rules:
         - alert: SYN_SchedulerLegacyPolicySet
@@ -2709,6 +2873,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-system-memory-exceeds-reservation
       rules:
         - alert: SYN_SystemMemoryExceedsReservation
@@ -2731,6 +2896,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-thanos-query
       rules:
         - alert: SYN_ThanosQueryGrpcClientErrorRate
@@ -2746,6 +2912,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryGrpcServerErrorRate
           annotations:
             description: Thanos Query {{$labels.job}} is failing to handle {{$value
@@ -2760,6 +2927,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHighDNSFailures
           annotations:
             description: Thanos Query {{$labels.job}} have {{$value | humanize}}%
@@ -2773,6 +2941,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHttpRequestQueryErrorRateHigh
           annotations:
             description: Thanos Query {{$labels.job}} is failing to handle {{$value
@@ -2787,6 +2956,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHttpRequestQueryRangeErrorRateHigh
           annotations:
             description: Thanos Query {{$labels.job}} is failing to handle {{$value
@@ -2801,6 +2971,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-thanos-rule
       rules:
         - alert: SYN_ThanosNoRuleEvaluations
@@ -2816,6 +2987,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleAlertmanagerHighDNSFailures
           annotations:
             description: Thanos Rule {{$labels.instance}} has {{$value | humanize}}%
@@ -2829,6 +3001,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleConfigReloadFailure
           annotations:
             description: Thanos Rule {{$labels.job}} has not been able to reload its
@@ -2841,6 +3014,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleGrpcErrorRate
           annotations:
             description: Thanos Rule {{$labels.job}} is failing to handle {{$value
@@ -2855,6 +3029,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleHighRuleEvaluationFailures
           annotations:
             description: Thanos Rule {{$labels.instance}} is failing to evaluate rules.
@@ -2867,6 +3042,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleHighRuleEvaluationWarnings
           annotations:
             description: Thanos Rule {{$labels.instance}} has high number of evaluation
@@ -2881,6 +3057,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleNoEvaluationFor10Intervals
           annotations:
             description: Thanos Rule {{$labels.job}} has {{$value | humanize}}% rule
@@ -2898,6 +3075,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleQueryHighDNSFailures
           annotations:
             description: Thanos Rule {{$labels.job}} has {{$value | humanize}}% of
@@ -2911,6 +3089,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleQueueIsDroppingAlerts
           annotations:
             description: Thanos Rule {{$labels.instance}} is failing to queue alerts.
@@ -2925,6 +3104,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleRuleEvaluationLatencyHigh
           annotations:
             description: Thanos Rule {{$labels.instance}} has higher evaluation latency
@@ -2938,6 +3118,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleSenderIsFailingAlerts
           annotations:
             description: Thanos Rule {{$labels.instance}} is failing to send alerts
@@ -2952,3 +3133,4 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -26,6 +26,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorInsufficientCloudCreds
           annotations:
             description: The Cloud Credential Operator has determined that there are
@@ -42,6 +43,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorProvisioningFailed
           annotations:
             description: While processing a CredentialsRequest, the Cloud Credential
@@ -58,6 +60,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorStaleCredentials
           annotations:
             message: 1 or more credentials requests are stale and should be deleted.
@@ -70,6 +73,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorTargetNamespaceMissing
           annotations:
             description: At least one CredentialsRequest custom resource has specified
@@ -89,6 +93,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-ImageRegistryOperator
       rules:
         - alert: SYN_ImageRegistryStorageReconfigured
@@ -105,6 +110,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-SamplesOperator
       rules:
         - alert: SYN_SamplesDegraded
@@ -119,6 +125,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesImagestreamImportFailing
           annotations:
             message: "Samples operator is detecting problems with imagestream image\
@@ -137,6 +144,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesInvalidConfig
           annotations:
             message: 'Samples operator has been given an invalid configuration.
@@ -148,6 +156,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesMissingSecret
           annotations:
             message: 'Samples operator cannot find the samples pull secret in the
@@ -160,6 +169,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesMissingTBRCredential
           annotations:
             message: 'The samples operator cannot find credentials for ''registry.redhat.io''.
@@ -174,6 +184,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesRetriesMissingOnImagestreamImportFailing
           annotations:
             message: "Samples operator is detecting problems with imagestream image\
@@ -194,6 +205,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesTBRInaccessibleOnBoot
           annotations:
             message: 'One of two situations has occurred.  Either
@@ -228,6 +240,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-alertmanager.rules
       rules:
         - alert: SYN_AlertmanagerClusterDown
@@ -246,6 +259,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -262,6 +276,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -278,6 +293,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -292,6 +308,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerFailedReload
           annotations:
             description: Configuration has failed to load for {{ $labels.namespace
@@ -313,6 +330,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -327,6 +345,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -344,6 +363,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-apiserver-requests-in-flight
       rules: []
     - name: syn-cluster-machine-approver.rules
@@ -359,6 +379,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-network-operator-sdn.rules
       rules:
         - alert: SYN_ClusterProxyApplySlow
@@ -373,6 +394,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeProxyApplySlow
           annotations:
             summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node
@@ -385,6 +407,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeProxyApplyStale
           annotations:
             summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node
@@ -401,6 +424,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeWithoutSDNPod
           annotations:
             summary: All nodes should be running an sdn pod, {{"{{"}} $labels.node
@@ -414,6 +438,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SDNPodNotReady
           annotations:
             summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node
@@ -427,6 +452,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-operators
       rules:
         - alert: SYN_ClusterNotUpgradeable
@@ -452,6 +478,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorDegraded
           annotations:
             description: The {{ $labels.name }} operator is degraded because {{ $labels.reason
@@ -470,6 +497,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorDown
           annotations:
             description: The {{ $labels.name }} operator may be down or disabled,
@@ -488,6 +516,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorFlapping
           annotations:
             description: The  {{ $labels.name }} operator behavior might cause upgrades
@@ -505,6 +534,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-version
       rules:
         - alert: SYN_CannotRetrieveUpdates
@@ -532,6 +562,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterVersionOperatorDown
           annotations:
             description: The operator may be down or disabled. The cluster will not
@@ -551,6 +582,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeControllerManagerDown
           annotations:
             message: KubeControllerManager has disappeared from Prometheus target
@@ -563,6 +595,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeSchedulerDown
           annotations:
             message: KubeScheduler has disappeared from Prometheus target discovery.
@@ -574,6 +607,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PodDisruptionBudgetAtLimit
           annotations:
             message: The pod disruption budget is preventing further disruption to
@@ -587,6 +621,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PodDisruptionBudgetLimit
           annotations:
             message: The pod disruption budget is below the minimum number allowed
@@ -600,6 +635,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_TechPreviewNoUpgrade
           annotations:
             message: Cluster has enabled tech preview features that will prevent upgrades.
@@ -612,6 +648,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_UpdateAvailable
           annotations:
             description: For more information refer to 'oc adm upgrade'{{ with $console_url
@@ -627,6 +664,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-control-plane-cpu-utilization
       rules:
         - alert: SYN_ExtremelyHighIndividualControlPlaneCPU
@@ -653,6 +691,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_HighOverallControlPlaneCPU
           annotations:
             message: Given three control plane nodes, the overall CPU utilization
@@ -675,6 +714,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-etcd
       rules:
         - alert: SYN_etcdDatabaseHighFragmentationRatio
@@ -695,6 +735,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdDatabaseQuotaLowSpace
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": database size exceeds
@@ -712,6 +753,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdExcessiveDatabaseGrowth
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": Predicting running out
@@ -727,6 +769,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdGRPCRequestsSlow
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile of gRPC
@@ -745,6 +788,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighCommitDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit
@@ -760,6 +804,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighFsyncDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
@@ -775,6 +820,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighFsyncDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
@@ -791,6 +837,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedProposals
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }} proposal
@@ -806,6 +853,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdMemberCommunicationSlow
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": member communication with
@@ -822,6 +870,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdMembersDown
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value
@@ -836,6 +885,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdNoLeader
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": member {{ $labels.instance
@@ -850,6 +900,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-general.rules
       rules:
         - alert: Watchdog
@@ -877,6 +928,7 @@ spec:
             namespace: openshift-monitoring
             severity: none
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-k8s.rules
       rules: []
     - name: syn-kube-apiserver-slos-basic
@@ -904,6 +956,7 @@ spec:
             severity: critical
             short: 5m
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget. This alert
@@ -927,6 +980,7 @@ spec:
             severity: critical
             short: 30m
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kube-apiserver.rules
       rules: []
     - name: syn-kube-prometheus-general.rules
@@ -951,6 +1005,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -965,6 +1020,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubelet.rules
       rules: []
     - name: syn-kubernetes-apps
@@ -983,6 +1039,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -997,6 +1054,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -1010,6 +1068,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -1034,6 +1093,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -1048,6 +1108,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeHpaMaxedOut
           annotations:
             description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
@@ -1061,6 +1122,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeHpaReplicasMismatch
           annotations:
             description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
@@ -1083,6 +1145,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeJobCompletion
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -1098,6 +1161,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -1114,6 +1178,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePodCrashLooping
           annotations:
             description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
@@ -1129,6 +1194,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -1145,6 +1211,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1159,6 +1226,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1175,6 +1243,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1194,6 +1263,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-recurring.rules
       rules: []
     - name: syn-kubernetes-resources
@@ -1218,6 +1288,7 @@ spec:
             namespace: kube-system
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeCPUQuotaOvercommit
           annotations:
             description: Cluster has overcommitted CPU resource requests for Namespaces.
@@ -1230,6 +1301,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeMemoryOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Pods
@@ -1251,6 +1323,7 @@ spec:
             namespace: kube-system
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Namespaces.
@@ -1264,6 +1337,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1278,6 +1352,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1292,6 +1367,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1306,6 +1382,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-storage
       rules:
         - alert: SYN_KubePersistentVolumeErrors
@@ -1322,6 +1399,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -1339,6 +1417,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -1359,6 +1438,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system
       rules:
         - alert: SYN_KubeClientErrors
@@ -1374,6 +1454,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system-apiserver
       rules:
         - alert: SYN_AggregatedAPIDown
@@ -1390,6 +1471,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AggregatedAPIErrors
           annotations:
             description: An aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -1404,6 +1486,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPIDown
           annotations:
             description: KubeAPI has disappeared from Prometheus target discovery.
@@ -1417,6 +1500,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPITerminatedRequests
           annotations:
             description: The apiserver has terminated {{ $value | humanizePercentage
@@ -1433,6 +1517,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system-kubelet
       rules:
         - alert: SYN_KubeNodeNotReady
@@ -1449,6 +1534,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -1463,6 +1549,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -1478,6 +1565,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -1492,6 +1580,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -1506,6 +1595,7 @@ spec:
             namespace: kube-system
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -1520,6 +1610,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -1535,6 +1626,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -1548,6 +1640,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -1563,6 +1656,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-api-operator-metrics-collector-up
       rules:
         - alert: SYN_MachineAPIOperatorMetricsCollectionFailing
@@ -1578,6 +1672,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-health-check-unterminated-short-circuit
       rules:
         - alert: SYN_MachineHealthCheckUnterminatedShortCircuit
@@ -1598,6 +1693,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-not-yet-deleted
       rules:
         - alert: SYN_MachineNotYetDeleted
@@ -1622,6 +1718,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-with-no-running-phase
       rules:
         - alert: SYN_MachineWithNoRunningPhase
@@ -1645,6 +1742,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-without-valid-node-ref
       rules:
         - alert: SYN_MachineWithoutValidNode
@@ -1666,6 +1764,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-master-nodes-high-memory-usage
       rules:
         - alert: SYN_MasterNodesHighMemoryUsage
@@ -1687,6 +1786,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-drain-error
       rules:
         - alert: SYN_MCDDrainError
@@ -1701,6 +1801,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-kubelet-health-state-error
       rules:
         - alert: SYN_KubeletHealthState
@@ -1713,6 +1814,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-pivot-error
       rules:
         - alert: SYN_MCDPivotError
@@ -1725,6 +1827,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-reboot-error
       rules:
         - alert: SYN_MCDRebootError
@@ -1737,6 +1840,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-exporter
       rules:
         - alert: SYN_NodeClockNotSynchronising
@@ -1756,6 +1860,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeClockSkewDetected
           annotations:
             description: Clock on {{ $labels.instance }} is out of sync by more than
@@ -1769,6 +1874,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -1782,6 +1888,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -1795,6 +1902,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1810,6 +1918,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1825,6 +1934,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1840,6 +1950,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1855,6 +1966,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1873,6 +1985,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1891,6 +2004,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1909,6 +2023,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -1927,6 +2042,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $value | humanizePercentage }} of conntrack entries are
@@ -1939,6 +2055,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -1954,6 +2071,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -1969,6 +2087,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' on {{ $labels.instance
@@ -1985,6 +2104,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array on {{ $labels.instance
@@ -1998,6 +2118,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector failed to scrape.
@@ -2009,6 +2130,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-exporter.rules
       rules: []
     - name: syn-node-network
@@ -2028,6 +2150,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-utilization
       rules:
         - alert: SYN_node_cpu_load5
@@ -2041,6 +2164,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_node_memory_free_percent
           annotations:
             message: '{{ $labels.node }}: Memory usage more than 97% (current value
@@ -2052,6 +2176,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node.rules
       rules: []
     - name: syn-olm.failing_operators.rules
@@ -2065,6 +2190,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-build.rules
       rules: []
     - name: syn-openshift-etcd-telemetry.rules
@@ -2088,6 +2214,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdInsufficientMembers
           annotations:
             description: etcd is reporting fewer instances are available than are
@@ -2108,6 +2235,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-general.rules
       rules:
         - alert: SYN_HighlyAvailableWorkloadIncorrectlySpread
@@ -2133,6 +2261,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_TargetDown
           annotations:
             description: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{
@@ -2152,6 +2281,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-ingress.rules
       rules:
         - alert: SYN_HAProxyDown
@@ -2164,6 +2294,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_HAProxyReloadFail
           annotations:
             message: HAProxy reloads are failing on {{ $labels.pod }}. Router is not
@@ -2174,6 +2305,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_IngressControllerDegraded
           annotations:
             message: 'The {{ $labels.namespace }}/{{ $labels.name }} ingresscontroller
@@ -2188,6 +2320,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_IngressControllerUnavailable
           annotations:
             message: 'The {{ $labels.namespace }}/{{ $labels.name }} ingresscontroller
@@ -2202,6 +2335,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-kubernetes.rules
       rules:
         - alert: SYN_AlertmanagerReceiversNotConfigured
@@ -2218,6 +2352,7 @@ spec:
             namespace: openshift-monitoring
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterMonitoringOperatorReconciliationErrors
           annotations:
             description: Errors are occurring during reconciliation cycles. Inspect
@@ -2231,6 +2366,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -2255,6 +2391,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_MultipleContainersOOMKilled
           annotations:
             description: Multiple containers were out of memory killed within the
@@ -2270,6 +2407,7 @@ spec:
             namespace: kube-system
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-monitoring.rules
       rules: []
     - name: syn-openshift-sre.rules
@@ -2295,6 +2433,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_APIRemovedInNextReleaseInUse
           annotations:
             message: Deprecated API that will be removed in the next version is being
@@ -2314,6 +2453,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-prometheus
       rules:
         - alert: SYN_PrometheusBadConfig
@@ -2336,6 +2476,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -2351,6 +2492,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -2366,6 +2508,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -2382,6 +2525,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -2397,6 +2541,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -2417,6 +2562,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -2432,6 +2578,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -2448,6 +2595,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -2463,6 +2611,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -2481,6 +2630,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -2498,6 +2648,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -2517,6 +2668,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -2531,6 +2683,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -2545,6 +2698,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -2559,6 +2713,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -2575,6 +2730,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -2590,6 +2746,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-prometheus-operator
       rules:
         - alert: SYN_PrometheusOperatorListErrors
@@ -2607,6 +2764,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -2621,6 +2779,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -2635,6 +2794,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -2651,6 +2811,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -2666,6 +2827,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -2680,6 +2842,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -2695,6 +2858,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-scheduler-legacy-policy-deprecated
       rules:
         - alert: SYN_SchedulerLegacyPolicySet
@@ -2709,6 +2873,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-system-memory-exceeds-reservation
       rules:
         - alert: SYN_SystemMemoryExceedsReservation
@@ -2731,6 +2896,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-thanos-query
       rules:
         - alert: SYN_ThanosQueryGrpcClientErrorRate
@@ -2746,6 +2912,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryGrpcServerErrorRate
           annotations:
             description: Thanos Query {{$labels.job}} is failing to handle {{$value
@@ -2760,6 +2927,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHighDNSFailures
           annotations:
             description: Thanos Query {{$labels.job}} have {{$value | humanize}}%
@@ -2773,6 +2941,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHttpRequestQueryErrorRateHigh
           annotations:
             description: Thanos Query {{$labels.job}} is failing to handle {{$value
@@ -2787,6 +2956,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHttpRequestQueryRangeErrorRateHigh
           annotations:
             description: Thanos Query {{$labels.job}} is failing to handle {{$value
@@ -2801,6 +2971,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-thanos-rule
       rules:
         - alert: SYN_ThanosNoRuleEvaluations
@@ -2816,6 +2987,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleAlertmanagerHighDNSFailures
           annotations:
             description: Thanos Rule {{$labels.instance}} has {{$value | humanize}}%
@@ -2829,6 +3001,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleConfigReloadFailure
           annotations:
             description: Thanos Rule {{$labels.job}} has not been able to reload its
@@ -2841,6 +3014,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleGrpcErrorRate
           annotations:
             description: Thanos Rule {{$labels.job}} is failing to handle {{$value
@@ -2855,6 +3029,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleHighRuleEvaluationFailures
           annotations:
             description: Thanos Rule {{$labels.instance}} is failing to evaluate rules.
@@ -2867,6 +3042,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleHighRuleEvaluationWarnings
           annotations:
             description: Thanos Rule {{$labels.instance}} has high number of evaluation
@@ -2881,6 +3057,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleNoEvaluationFor10Intervals
           annotations:
             description: Thanos Rule {{$labels.job}} has {{$value | humanize}}% rule
@@ -2898,6 +3075,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleQueryHighDNSFailures
           annotations:
             description: Thanos Rule {{$labels.job}} has {{$value | humanize}}% of
@@ -2911,6 +3089,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleQueueIsDroppingAlerts
           annotations:
             description: Thanos Rule {{$labels.instance}} is failing to queue alerts.
@@ -2925,6 +3104,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleRuleEvaluationLatencyHigh
           annotations:
             description: Thanos Rule {{$labels.instance}} has higher evaluation latency
@@ -2938,6 +3118,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleSenderIsFailingAlerts
           annotations:
             description: Thanos Rule {{$labels.instance}} is failing to send alerts
@@ -2952,3 +3133,4 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -26,6 +26,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorInsufficientCloudCreds
           annotations:
             description: The Cloud Credential Operator has determined that there are
@@ -42,6 +43,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorProvisioningFailed
           annotations:
             description: While processing a CredentialsRequest, the Cloud Credential
@@ -58,6 +60,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorStaleCredentials
           annotations:
             description: The Cloud Credential Operator (CCO) has detected one or more
@@ -82,6 +85,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_CloudCredentialOperatorTargetNamespaceMissing
           annotations:
             description: At least one CredentialsRequest custom resource has specified
@@ -101,6 +105,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-SamplesOperator
       rules:
         - alert: SYN_SamplesDegraded
@@ -116,6 +121,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesImagestreamImportFailing
           annotations:
             description: "Samples operator is detecting problems with imagestream\
@@ -137,6 +143,7 @@ spec:
             namespace: openshift-cluster-samples-operator
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesInvalidConfig
           annotations:
             description: 'Samples operator has been given an invalid configuration.
@@ -149,6 +156,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesMissingSecret
           annotations:
             description: 'Samples operator cannot find the samples pull secret in
@@ -162,6 +170,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesMissingTBRCredential
           annotations:
             description: 'The samples operator cannot find credentials for ''registry.redhat.io''.
@@ -177,6 +186,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesRetriesMissingOnImagestreamImportFailing
           annotations:
             description: "Samples operator is detecting problems with imagestream\
@@ -200,6 +210,7 @@ spec:
             namespace: openshift-cluster-samples-operator
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SamplesTBRInaccessibleOnBoot
           annotations:
             description: 'One of two situations has occurred.  Either
@@ -237,6 +248,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-alertmanager.rules
       rules:
         - alert: SYN_AlertmanagerClusterDown
@@ -255,6 +267,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerClusterFailedToSendAlerts
           annotations:
             description: The minimum notification failure rate to {{ $labels.integration
@@ -271,6 +284,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerConfigInconsistent
           annotations:
             description: Alertmanager instances within the {{$labels.job}} cluster
@@ -285,6 +299,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerFailedReload
           annotations:
             description: Configuration has failed to load for {{ $labels.namespace
@@ -306,6 +321,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerFailedToSendAlerts
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -321,6 +337,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_AlertmanagerMembersInconsistent
           annotations:
             description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
@@ -338,6 +355,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-apiserver-requests-in-flight
       rules: []
     - name: syn-cluster-machine-approver.rules
@@ -365,6 +383,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-network-operator-sdn.rules
       rules:
         - alert: SYN_ClusterProxyApplySlow
@@ -382,6 +401,7 @@ spec:
             namespace: openshift-sdn
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeProxyApplySlow
           annotations:
             description: Configuration of proxy rules for Kubernetes services in the
@@ -398,6 +418,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeProxyApplyStale
           annotations:
             description: Stale proxy rules for Kubernetes services may increase the
@@ -416,6 +437,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeWithoutSDNController
           annotations:
             description: 'If at least one OpenShift SDN controller is ''Running'',
@@ -434,6 +456,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeWithoutSDNPod
           annotations:
             description: Network control plane configuration on the node could be
@@ -449,6 +472,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_SDNPodNotReady
           annotations:
             description: Network control plane configuration on the node could be
@@ -464,6 +488,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-operators
       rules:
         - alert: SYN_ClusterNotUpgradeable
@@ -489,6 +514,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorDegraded
           annotations:
             description: The {{ $labels.name }} operator is degraded because {{ $labels.reason
@@ -507,6 +533,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorDown
           annotations:
             description: The {{ $labels.name }} operator may be down or disabled,
@@ -525,6 +552,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterOperatorFlapping
           annotations:
             description: The  {{ $labels.name }} operator behavior might cause upgrades
@@ -542,6 +570,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-cluster-version
       rules:
         - alert: SYN_CannotRetrieveUpdates
@@ -569,6 +598,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterVersionOperatorDown
           annotations:
             description: The operator may be down or disabled. The cluster will not
@@ -588,6 +618,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_GarbageCollectorSyncFailed
           annotations:
             description: Garbage Collector had a problem with syncing and monitoring
@@ -604,6 +635,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeControllerManagerDown
           annotations:
             description: KubeControllerManager has disappeared from Prometheus target
@@ -619,6 +651,7 @@ spec:
             namespace: openshift-kube-controller-manager
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeSchedulerDown
           annotations:
             description: KubeScheduler has disappeared from Prometheus target discovery.
@@ -632,6 +665,7 @@ spec:
             namespace: openshift-kube-scheduler
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PodDisruptionBudgetAtLimit
           annotations:
             description: The pod disruption budget is at the minimum disruptions allowed
@@ -650,6 +684,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PodDisruptionBudgetLimit
           annotations:
             description: The pod disruption budget is below the minimum disruptions
@@ -666,6 +701,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_TechPreviewNoUpgrade
           annotations:
             description: Cluster has enabled Technology Preview features that cannot
@@ -681,6 +717,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_UpdateAvailable
           annotations:
             description: For more information refer to 'oc adm upgrade'{{ with $console_url
@@ -696,6 +733,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-config-reloaders
       rules:
         - alert: SYN_ConfigReloaderSidecarErrors
@@ -715,6 +753,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-control-plane-cpu-utilization
       rules:
         - alert: SYN_ExtremelyHighIndividualControlPlaneCPU
@@ -742,6 +781,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ExtremelyHighIndividualControlPlaneCPU
           annotations:
             description: Extreme CPU pressure can cause slow serialization and poor
@@ -767,6 +807,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_HighOverallControlPlaneCPU
           annotations:
             description: Given three control plane nodes, the overall CPU utilization
@@ -790,6 +831,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-etcd
       rules:
         - alert: SYN_etcdDatabaseHighFragmentationRatio
@@ -810,6 +852,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdDatabaseQuotaLowSpace
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": database size exceeds
@@ -827,6 +870,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdExcessiveDatabaseGrowth
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": Predicting running out
@@ -842,6 +886,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighCommitDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit
@@ -857,6 +902,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighFsyncDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
@@ -872,6 +918,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighFsyncDurations
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
@@ -888,6 +935,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedProposals
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }} proposal
@@ -903,6 +951,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdMemberCommunicationSlow
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": member communication with
@@ -919,6 +968,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdMembersDown
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value
@@ -933,6 +983,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdNoLeader
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": member {{ $labels.instance
@@ -947,6 +998,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-extremely-high-individual-control-plane-memory
       rules:
         - alert: SYN_ExtremelyHighIndividualControlPlaneMemory
@@ -973,6 +1025,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-general.rules
       rules:
         - alert: Watchdog
@@ -1000,6 +1053,7 @@ spec:
             namespace: openshift-monitoring
             severity: none
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-high-overall-control-plane-memory
       rules:
         - alert: SYN_HighOverallControlPlaneMemory
@@ -1038,6 +1092,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-k8s.rules
       rules: []
     - name: syn-kube-apiserver-slos-basic
@@ -1066,6 +1121,7 @@ spec:
             severity: critical
             short: 5m
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPIErrorBudgetBurn
           annotations:
             description: The API server is burning too much error budget. This alert
@@ -1090,6 +1146,7 @@ spec:
             severity: critical
             short: 30m
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kube-apiserver.rules
       rules: []
     - name: syn-kube-prometheus-general.rules
@@ -1114,6 +1171,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStateMetricsWatchErrors
           annotations:
             description: kube-state-metrics is experiencing errors at an elevated
@@ -1128,6 +1186,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubelet.rules
       rules: []
     - name: syn-kubernetes-apps
@@ -1147,6 +1206,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetMisScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -1161,6 +1221,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetNotScheduled
           annotations:
             description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
@@ -1174,6 +1235,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDaemonSetRolloutStuck
           annotations:
             description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
@@ -1198,6 +1260,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDeploymentGenerationMismatch
           annotations:
             description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -1212,6 +1275,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeHpaMaxedOut
           annotations:
             description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
@@ -1225,6 +1289,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeHpaReplicasMismatch
           annotations:
             description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
@@ -1247,6 +1312,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeJobFailed
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
@@ -1263,6 +1329,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeJobNotCompleted
           annotations:
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
@@ -1276,6 +1343,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePodCrashLooping
           annotations:
             description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
@@ -1291,6 +1359,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePodNotReady
           annotations:
             description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
@@ -1308,6 +1377,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetGenerationMismatch
           annotations:
             description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1322,6 +1392,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetReplicasMismatch
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1338,6 +1409,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeStatefulSetUpdateNotRolledOut
           annotations:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
@@ -1357,6 +1429,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-recurring.rules
       rules: []
     - name: syn-kubernetes-resources
@@ -1381,6 +1454,7 @@ spec:
             namespace: kube-system
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeCPUQuotaOvercommit
           annotations:
             description: Cluster has overcommitted CPU resource requests for Namespaces.
@@ -1394,6 +1468,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeMemoryOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Pods
@@ -1415,6 +1490,7 @@ spec:
             namespace: kube-system
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeMemoryQuotaOvercommit
           annotations:
             description: Cluster has overcommitted memory resource requests for Namespaces.
@@ -1428,6 +1504,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaAlmostFull
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1442,6 +1519,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaExceeded
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1456,6 +1534,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeQuotaFullyUsed
           annotations:
             description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
@@ -1470,6 +1549,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-storage
       rules:
         - alert: SYN_KubePersistentVolumeErrors
@@ -1486,6 +1566,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -1508,6 +1589,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -1533,6 +1615,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeInodesFillingUp
           annotations:
             description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
@@ -1555,6 +1638,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubePersistentVolumeInodesFillingUp
           annotations:
             description: Based on recent sampling, the PersistentVolume claimed by
@@ -1580,6 +1664,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system
       rules:
         - alert: SYN_KubeClientErrors
@@ -1595,6 +1680,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system-apiserver
       rules:
         - alert: SYN_KubeAPIDown
@@ -1610,6 +1696,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAPITerminatedRequests
           annotations:
             description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
@@ -1626,6 +1713,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAggregatedAPIDown
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -1640,6 +1728,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeAggregatedAPIErrors
           annotations:
             description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
@@ -1654,6 +1743,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-kubernetes-system-kubelet
       rules:
         - alert: SYN_KubeNodeNotReady
@@ -1670,6 +1760,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeNodeReadinessFlapping
           annotations:
             description: The readiness status of node {{ $labels.node }} has changed
@@ -1684,6 +1775,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeNodeUnreachable
           annotations:
             description: '{{ $labels.node }} is unreachable and some workloads may
@@ -1699,6 +1791,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletClientCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -1713,6 +1806,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletDown
           annotations:
             description: Kubelet has disappeared from Prometheus target discovery.
@@ -1727,6 +1821,7 @@ spec:
             namespace: kube-system
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletPlegDurationHigh
           annotations:
             description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
@@ -1741,6 +1836,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletPodStartUpLatencyHigh
           annotations:
             description: Kubelet Pod startup 99th percentile latency is {{ $value
@@ -1757,6 +1853,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletServerCertificateRenewalErrors
           annotations:
             description: Kubelet on node {{ $labels.node }} has failed to renew its
@@ -1770,6 +1867,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeletTooManyPods
           annotations:
             description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
@@ -1785,6 +1883,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-api-operator-metrics-collector-up
       rules:
         - alert: SYN_MachineAPIOperatorMetricsCollectionFailing
@@ -1800,6 +1899,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-health-check-unterminated-short-circuit
       rules:
         - alert: SYN_MachineHealthCheckUnterminatedShortCircuit
@@ -1820,6 +1920,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-not-yet-deleted
       rules:
         - alert: SYN_MachineNotYetDeleted
@@ -1844,6 +1945,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-with-no-running-phase
       rules:
         - alert: SYN_MachineWithNoRunningPhase
@@ -1867,6 +1969,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-machine-without-valid-node-ref
       rules:
         - alert: SYN_MachineWithoutValidNode
@@ -1888,6 +1991,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcc-paused-pool-kubelet-ca
       rules:
         - alert: SYN_MachineConfigControllerPausedPoolKubeletCA
@@ -1918,6 +2022,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_MachineConfigControllerPausedPoolKubeletCA
           annotations:
             description: Machine config pools have a 'pause' feature, which allows
@@ -1948,6 +2053,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-drain-error
       rules:
         - alert: SYN_MCDDrainError
@@ -1962,6 +2068,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-kubelet-health-state-error
       rules:
         - alert: SYN_KubeletHealthState
@@ -1974,6 +2081,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-pivot-error
       rules:
         - alert: SYN_MCDPivotError
@@ -1986,6 +2094,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-mcd-reboot-error
       rules:
         - alert: SYN_MCDRebootError
@@ -1998,6 +2107,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-exporter
       rules:
         - alert: SYN_NodeClockNotSynchronising
@@ -2018,6 +2128,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeClockSkewDetected
           annotations:
             description: Clock on {{ $labels.instance }} is out of sync by more than
@@ -2031,6 +2142,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -2044,6 +2156,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFileDescriptorLimit
           annotations:
             description: File descriptors limit at {{ $labels.instance }} is currently
@@ -2057,6 +2170,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2072,6 +2186,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfFiles
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2087,6 +2202,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2102,6 +2218,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemAlmostOutOfSpace
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2117,6 +2234,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2135,6 +2253,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemFilesFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2153,6 +2272,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2171,6 +2291,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeFilesystemSpaceFillingUp
           annotations:
             description: Filesystem on {{ $labels.device }} at {{ $labels.instance
@@ -2189,6 +2310,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeHighNumberConntrackEntriesUsed
           annotations:
             description: '{{ $value | humanizePercentage }} of conntrack entries are
@@ -2201,6 +2323,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeNetworkReceiveErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -2216,6 +2339,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeNetworkTransmitErrs
           annotations:
             description: '{{ $labels.instance }} interface {{ $labels.device }} has
@@ -2231,6 +2355,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeRAIDDegraded
           annotations:
             description: RAID array '{{ $labels.device }}' on {{ $labels.instance
@@ -2247,6 +2372,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeRAIDDiskFailure
           annotations:
             description: At least one device in RAID array on {{ $labels.instance
@@ -2260,6 +2386,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_NodeTextFileCollectorScrapeError
           annotations:
             description: Node Exporter text file collector failed to scrape.
@@ -2271,6 +2398,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-exporter.rules
       rules: []
     - name: syn-node-network
@@ -2290,6 +2418,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node-utilization
       rules:
         - alert: SYN_node_cpu_load5
@@ -2303,6 +2432,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_node_memory_free_percent
           annotations:
             message: '{{ $labels.node }}: Memory usage more than 97% (current value
@@ -2314,6 +2444,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-node.rules
       rules: []
     - name: syn-olm.failing_operators.rules
@@ -2327,6 +2458,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-build.rules
       rules: []
     - name: syn-openshift-etcd-telemetry.rules
@@ -2351,6 +2483,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedGRPCRequests
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
@@ -2366,6 +2499,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfFailedGRPCRequests
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
@@ -2382,6 +2516,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdHighNumberOfLeaderChanges
           annotations:
             description: 'etcd cluster "{{ $labels.job }}": {{ $value }} average leader
@@ -2397,6 +2532,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_etcdInsufficientMembers
           annotations:
             description: etcd is reporting fewer instances are available than are
@@ -2417,6 +2553,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-general.rules
       rules:
         - alert: SYN_TargetDown
@@ -2438,6 +2575,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-ingress.rules
       rules:
         - alert: SYN_HAProxyDown
@@ -2452,6 +2590,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_HAProxyReloadFail
           annotations:
             description: This alert fires when HAProxy fails to reload its configuration,
@@ -2466,6 +2605,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_IngressControllerDegraded
           annotations:
             description: This alert fires when the IngressController status is degraded.
@@ -2482,6 +2622,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_IngressControllerUnavailable
           annotations:
             description: This alert fires when the IngressController is not available.
@@ -2498,6 +2639,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-kubernetes.rules
       rules:
         - alert: SYN_AlertmanagerReceiversNotConfigured
@@ -2514,6 +2656,7 @@ spec:
             namespace: openshift-monitoring
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ClusterMonitoringOperatorReconciliationErrors
           annotations:
             description: Errors are occurring during reconciliation cycles. Inspect
@@ -2527,6 +2670,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_KubeDeploymentReplicasMismatch
           annotations:
             description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
@@ -2551,6 +2695,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_MultipleContainersOOMKilled
           annotations:
             description: Multiple containers were out of memory killed within the
@@ -2566,6 +2711,7 @@ spec:
             namespace: kube-system
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-openshift-monitoring.rules
       rules: []
     - name: syn-openshift-sre.rules
@@ -2593,6 +2739,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_APIRemovedInNextReleaseInUse
           annotations:
             description: Deprecated API that will be removed in the next version is
@@ -2614,6 +2761,7 @@ spec:
             namespace: openshift-kube-apiserver
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-prometheus
       rules:
         - alert: SYN_PrometheusBadConfig
@@ -2636,6 +2784,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -2651,6 +2800,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
             description: '{{ printf "%.1f" $value }}% errors while sending alerts
@@ -2666,6 +2816,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusLabelLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -2682,6 +2833,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
@@ -2697,6 +2849,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
@@ -2717,6 +2870,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotIngestingSamples
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
@@ -2732,6 +2886,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusNotificationQueueRunningFull
           annotations:
             description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -2748,6 +2903,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOutOfOrderTimestamps
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
@@ -2763,6 +2919,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteStorageFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
@@ -2781,6 +2938,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteWriteBehind
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -2798,6 +2956,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRemoteWriteDesiredShards
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -2817,6 +2976,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusRuleFailures
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -2831,6 +2991,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusScrapeBodySizeLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -2846,6 +3007,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusScrapeSampleLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
@@ -2862,6 +3024,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -2876,6 +3039,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
@@ -2890,6 +3054,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTargetLimitHit
           annotations:
             description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
@@ -2906,6 +3071,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusTargetSyncFailure
           annotations:
             description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -2921,6 +3087,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-prometheus-operator
       rules:
         - alert: SYN_PrometheusOperatorListErrors
@@ -2940,6 +3107,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorNodeLookupErrors
           annotations:
             description: Errors while reconciling Prometheus in {{ $labels.namespace
@@ -2955,6 +3123,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorNotReady
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -2970,6 +3139,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorReconcileErrors
           annotations:
             description: '{{ $value | humanizePercentage }} of reconciling operations
@@ -2988,6 +3158,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorRejectedResources
           annotations:
             description: Prometheus operator in {{ $labels.namespace }} namespace
@@ -3003,6 +3174,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorSyncFailed
           annotations:
             description: Controller {{ $labels.controller }} in {{ $labels.namespace
@@ -3018,6 +3190,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_PrometheusOperatorWatchErrors
           annotations:
             description: Errors while performing watch operations in controller {{$labels.controller}}
@@ -3035,6 +3208,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-scheduler-legacy-policy-deprecated
       rules:
         - alert: SYN_SchedulerLegacyPolicySet
@@ -3050,6 +3224,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-system-memory-exceeds-reservation
       rules:
         - alert: SYN_SystemMemoryExceedsReservation
@@ -3072,6 +3247,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-thanos-query
       rules:
         - alert: SYN_ThanosQueryGrpcClientErrorRate
@@ -3087,6 +3263,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryGrpcServerErrorRate
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
@@ -3101,6 +3278,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHighDNSFailures
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} have
@@ -3114,6 +3292,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHttpRequestQueryErrorRateHigh
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
@@ -3128,6 +3307,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosQueryHttpRequestQueryRangeErrorRateHigh
           annotations:
             description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
@@ -3142,6 +3322,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
     - name: syn-thanos-rule
       rules:
         - alert: SYN_ThanosNoRuleEvaluations
@@ -3157,6 +3338,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleAlertmanagerHighDNSFailures
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3170,6 +3352,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleConfigReloadFailure
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
@@ -3182,6 +3365,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleGrpcErrorRate
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} is failing
@@ -3197,6 +3381,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleHighRuleEvaluationFailures
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3210,6 +3395,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleHighRuleEvaluationWarnings
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3224,6 +3410,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleNoEvaluationFor10Intervals
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
@@ -3242,6 +3429,7 @@ spec:
           labels:
             severity: info
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleQueryHighDNSFailures
           annotations:
             description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
@@ -3255,6 +3443,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleQueueIsDroppingAlerts
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3270,6 +3459,7 @@ spec:
           labels:
             severity: critical
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleRuleEvaluationLatencyHigh
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3284,6 +3474,7 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring
         - alert: SYN_ThanosRuleSenderIsFailingAlerts
           annotations:
             description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
@@ -3298,3 +3489,4 @@ spec:
           labels:
             severity: warning
             syn: 'true'
+            syn_component: openshift4-monitoring


### PR DESCRIPTION
The library provides functions `patchRule()`, `filterRules()` and `filterPatchRules()`. The functions are documented using doxygen-style comments which have been manually transferred to an asciidoc reference page.

We also use the new library to render our own alerting rules. This injects `syn_component: openshift4-monitoring` to all alerts rendered by this component.

Relates to https://github.com/appuio/component-openshift4-logging/issues/64




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
