### PR TITLE
Adjust HighOverallControlPlaneMemory alert on OCP4.11

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -90,7 +90,35 @@ parameters:
     alerts:
       ignoreNames: []
       customAnnotations: {}
-      patchRules: {}
+      patchRules:
+        release-4.11:
+          HighOverallControlPlaneMemory:
+            description: |
+              The overall memory usage is high.
+              kube-apiserver and etcd might be slow to respond.
+              To fix this, increase memory of the control plane nodes.
+
+              This alert was adjusted to be less sensitive in 4.11.
+              Newer Go versions use more memory, if available, to reduce GC pauses.
+
+              Old memory behavior can be restored by setting `GOGC=63`.
+              See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
+            expr: |
+              (
+                1
+                -
+                sum (
+                  node_memory_MemFree_bytes
+                  + node_memory_Buffers_bytes
+                  + node_memory_Cached_bytes
+                  AND on (instance)
+                  label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
+                ) / sum (
+                  node_memory_MemTotal_bytes
+                  AND on (instance)
+                  label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
+                )
+              ) * 100 > 80
       # Alerts to ignore for user workload monitoring
       ignoreUserWorkload: []
 

--- a/tests/golden/es-operator-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/es-operator-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1012,12 +1012,29 @@ spec:
             summary: Memory utilization across all control plane nodes is high, and
               could impact responsiveness and stability.
             syn_component: openshift4-monitoring
+          description: 'The overall memory usage is high.
+
+            kube-apiserver and etcd might be slow to respond.
+
+            To fix this, increase memory of the control plane nodes.
+
+
+            This alert was adjusted to be less sensitive in 4.11.
+
+            Newer Go versions use more memory, if available, to reduce GC pauses.
+
+
+            Old memory behavior can be restored by setting `GOGC=63`.
+
+            See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
+
+            '
           expr: "(\n  1\n  -\n  sum (\n    node_memory_MemFree_bytes\n    + node_memory_Buffers_bytes\n\
             \    + node_memory_Cached_bytes\n    AND on (instance)\n    label_replace(\
             \ kube_node_role{role=\"master\"}, \"instance\", \"$1\", \"node\", \"\
             (.+)\" )\n  ) / sum (\n    node_memory_MemTotal_bytes\n    AND on (instance)\n\
             \    label_replace( kube_node_role{role=\"master\"}, \"instance\", \"\
-            $1\", \"node\", \"(.+)\" )\n  )\n) * 100 > 60\n"
+            $1\", \"node\", \"(.+)\" )\n  )\n) * 100 > 80\n"
           for: 1h
           labels:
             severity: warning

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1012,12 +1012,29 @@ spec:
             summary: Memory utilization across all control plane nodes is high, and
               could impact responsiveness and stability.
             syn_component: openshift4-monitoring
+          description: 'The overall memory usage is high.
+
+            kube-apiserver and etcd might be slow to respond.
+
+            To fix this, increase memory of the control plane nodes.
+
+
+            This alert was adjusted to be less sensitive in 4.11.
+
+            Newer Go versions use more memory, if available, to reduce GC pauses.
+
+
+            Old memory behavior can be restored by setting `GOGC=63`.
+
+            See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
+
+            '
           expr: "(\n  1\n  -\n  sum (\n    node_memory_MemFree_bytes\n    + node_memory_Buffers_bytes\n\
             \    + node_memory_Cached_bytes\n    AND on (instance)\n    label_replace(\
             \ kube_node_role{role=\"master\"}, \"instance\", \"$1\", \"node\", \"\
             (.+)\" )\n  ) / sum (\n    node_memory_MemTotal_bytes\n    AND on (instance)\n\
             \    label_replace( kube_node_role{role=\"master\"}, \"instance\", \"\
-            $1\", \"node\", \"(.+)\" )\n  )\n) * 100 > 60\n"
+            $1\", \"node\", \"(.+)\" )\n  )\n) * 100 > 80\n"
           for: 1h
           labels:
             severity: warning

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1011,12 +1011,29 @@ spec:
             summary: Memory utilization across all control plane nodes is high, and
               could impact responsiveness and stability.
             syn_component: openshift4-monitoring
+          description: 'The overall memory usage is high.
+
+            kube-apiserver and etcd might be slow to respond.
+
+            To fix this, increase memory of the control plane nodes.
+
+
+            This alert was adjusted to be less sensitive in 4.11.
+
+            Newer Go versions use more memory, if available, to reduce GC pauses.
+
+
+            Old memory behavior can be restored by setting `GOGC=63`.
+
+            See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
+
+            '
           expr: "(\n  1\n  -\n  sum (\n    node_memory_MemFree_bytes\n    + node_memory_Buffers_bytes\n\
             \    + node_memory_Cached_bytes\n    AND on (instance)\n    label_replace(\
             \ kube_node_role{role=\"master\"}, \"instance\", \"$1\", \"node\", \"\
             (.+)\" )\n  ) / sum (\n    node_memory_MemTotal_bytes\n    AND on (instance)\n\
             \    label_replace( kube_node_role{role=\"master\"}, \"instance\", \"\
-            $1\", \"node\", \"(.+)\" )\n  )\n) * 100 > 60\n"
+            $1\", \"node\", \"(.+)\" )\n  )\n) * 100 > 80\n"
           for: 1h
           labels:
             severity: warning


### PR DESCRIPTION
Go 1.18/ Kubernetes 1.24 adjusted how memory is freed on systems with enough free memory. Adjust alert to be less sensitive.

See https://bugzilla.redhat.com/show_bug.cgi?id=2074031.

> In Kubernetes 1.24 and later versions, the response latency is reduced by 10 times for 99% of the API requests handled by kube-apiserver and the loads of kube-apiserver increase by about 25%. This is because Kubernetes 1.24 is compiled with Go 1.18, which has significant changes in its garbage collection algorithm. If the memory usage increase of kube-apiserver is not acceptable, you can mitigate the impacts by setting the GOGC environment variable. You can specify GOGC=63 to bring the memory usage of kube-aspiserver back to the original level.

https://www.alibabacloud.com/help/en/container-service-for-kubernetes/latest/k8s124rn

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
