### PR TITLE
Fix patch for HighOverallControlPlaneMemory alert rule

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -94,16 +94,17 @@ parameters:
       patchRules:
         release-4.11:
           HighOverallControlPlaneMemory:
-            description: |
-              The overall memory usage is high.
-              kube-apiserver and etcd might be slow to respond.
-              To fix this, increase memory of the control plane nodes.
+            annotations:
+              description: |
+                The overall memory usage is high.
+                kube-apiserver and etcd might be slow to respond.
+                To fix this, increase memory of the control plane nodes.
 
-              This alert was adjusted to be less sensitive in 4.11.
-              Newer Go versions use more memory, if available, to reduce GC pauses.
+                This alert was adjusted to be less sensitive in 4.11.
+                Newer Go versions use more memory, if available, to reduce GC pauses.
 
-              Old memory behavior can be restored by setting `GOGC=63`.
-              See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
+                Old memory behavior can be restored by setting `GOGC=63`.
+                See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
             expr: |
               (
                 1

--- a/tests/golden/es-operator-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/es-operator-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1059,30 +1059,26 @@ spec:
       rules:
         - alert: SYN_HighOverallControlPlaneMemory
           annotations:
-            description: Given three control plane nodes, the overall memory utilization
-              may only be about 2/3 of all available capacity. This is because if
-              a single control plane node fails, the kube-apiserver and etcd my be
-              slow to respond. To fix this, increase memory of the control plane nodes.
+            description: 'The overall memory usage is high.
+
+              kube-apiserver and etcd might be slow to respond.
+
+              To fix this, increase memory of the control plane nodes.
+
+
+              This alert was adjusted to be less sensitive in 4.11.
+
+              Newer Go versions use more memory, if available, to reduce GC pauses.
+
+
+              Old memory behavior can be restored by setting `GOGC=63`.
+
+              See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
+
+              '
             summary: Memory utilization across all control plane nodes is high, and
               could impact responsiveness and stability.
             syn_component: openshift4-monitoring
-          description: 'The overall memory usage is high.
-
-            kube-apiserver and etcd might be slow to respond.
-
-            To fix this, increase memory of the control plane nodes.
-
-
-            This alert was adjusted to be less sensitive in 4.11.
-
-            Newer Go versions use more memory, if available, to reduce GC pauses.
-
-
-            Old memory behavior can be restored by setting `GOGC=63`.
-
-            See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
-
-            '
           expr: "(\n  1\n  -\n  sum (\n    node_memory_MemFree_bytes\n    + node_memory_Buffers_bytes\n\
             \    + node_memory_Cached_bytes\n    AND on (instance)\n    label_replace(\
             \ kube_node_role{role=\"master\"}, \"instance\", \"$1\", \"node\", \"\

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1059,30 +1059,26 @@ spec:
       rules:
         - alert: SYN_HighOverallControlPlaneMemory
           annotations:
-            description: Given three control plane nodes, the overall memory utilization
-              may only be about 2/3 of all available capacity. This is because if
-              a single control plane node fails, the kube-apiserver and etcd my be
-              slow to respond. To fix this, increase memory of the control plane nodes.
+            description: 'The overall memory usage is high.
+
+              kube-apiserver and etcd might be slow to respond.
+
+              To fix this, increase memory of the control plane nodes.
+
+
+              This alert was adjusted to be less sensitive in 4.11.
+
+              Newer Go versions use more memory, if available, to reduce GC pauses.
+
+
+              Old memory behavior can be restored by setting `GOGC=63`.
+
+              See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
+
+              '
             summary: Memory utilization across all control plane nodes is high, and
               could impact responsiveness and stability.
             syn_component: openshift4-monitoring
-          description: 'The overall memory usage is high.
-
-            kube-apiserver and etcd might be slow to respond.
-
-            To fix this, increase memory of the control plane nodes.
-
-
-            This alert was adjusted to be less sensitive in 4.11.
-
-            Newer Go versions use more memory, if available, to reduce GC pauses.
-
-
-            Old memory behavior can be restored by setting `GOGC=63`.
-
-            See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
-
-            '
           expr: "(\n  1\n  -\n  sum (\n    node_memory_MemFree_bytes\n    + node_memory_Buffers_bytes\n\
             \    + node_memory_Cached_bytes\n    AND on (instance)\n    label_replace(\
             \ kube_node_role{role=\"master\"}, \"instance\", \"$1\", \"node\", \"\

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1058,30 +1058,26 @@ spec:
       rules:
         - alert: SYN_HighOverallControlPlaneMemory
           annotations:
-            description: Given three control plane nodes, the overall memory utilization
-              may only be about 2/3 of all available capacity. This is because if
-              a single control plane node fails, the kube-apiserver and etcd my be
-              slow to respond. To fix this, increase memory of the control plane nodes.
+            description: 'The overall memory usage is high.
+
+              kube-apiserver and etcd might be slow to respond.
+
+              To fix this, increase memory of the control plane nodes.
+
+
+              This alert was adjusted to be less sensitive in 4.11.
+
+              Newer Go versions use more memory, if available, to reduce GC pauses.
+
+
+              Old memory behavior can be restored by setting `GOGC=63`.
+
+              See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
+
+              '
             summary: Memory utilization across all control plane nodes is high, and
               could impact responsiveness and stability.
             syn_component: openshift4-monitoring
-          description: 'The overall memory usage is high.
-
-            kube-apiserver and etcd might be slow to respond.
-
-            To fix this, increase memory of the control plane nodes.
-
-
-            This alert was adjusted to be less sensitive in 4.11.
-
-            Newer Go versions use more memory, if available, to reduce GC pauses.
-
-
-            Old memory behavior can be restored by setting `GOGC=63`.
-
-            See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
-
-            '
           expr: "(\n  1\n  -\n  sum (\n    node_memory_MemFree_bytes\n    + node_memory_Buffers_bytes\n\
             \    + node_memory_Cached_bytes\n    AND on (instance)\n    label_replace(\
             \ kube_node_role{role=\"master\"}, \"instance\", \"$1\", \"node\", \"\


### PR DESCRIPTION
This is a follow-up to #137, the patched alert rule isn't rolled out due to failing ArgoCD sync:
```
error validating data: ValidationError(PrometheusRule.spec.groups[12].rules[0]): unknown field "description" in com.coreos.monitoring.v1.PrometheusRule.spec.groups.rules
```

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
