### PR TITLE
Enable non-predictive capacity alerts by default 

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -151,7 +151,7 @@ parameters:
 
 
     capacityAlerts:
-      enabled: false
+      enabled: true
       groups:
         PodCapacity:
           rules:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -393,8 +393,8 @@ Number of successful jobs to keep.
 type:: dict
 
 This parameter allows users to enable and configure alerts for capacity management.
-The capacity alerts are disabled by default and can be enabled by setting the key `capacityAlerts.enabled` to `true`.
-Predictive alerts are disabled by default and can be enabled, as exampled by `ExpectClusterCpuUsageHigh.enabled` to `true`.
+The capacity alerts are enabled by default and can be disabled completely by setting the key `capacityAlerts.enabled` to `false`.
+Predictive alerts are disabled by default and can be enabled individually as shown below by setting `ExpectClusterCpuUsageHigh.enabled` to `true`.
 
 The dictionary will be transformed into a `PrometheusRule` object by the component.
 

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -25,7 +25,7 @@ metadata:
   name: silence
   namespace: openshift-monitoring
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations: {}

--- a/tests/golden/es-operator-rules/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
+++ b/tests/golden/es-operator-rules/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
@@ -1,0 +1,152 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    syn_component: openshift4-monitoring
+  labels:
+    name: capacity
+  name: capacity
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: syn-CpuCapacity
+      rules:
+        - alert: SYN_ClusterCpuUsageHigh
+          annotations:
+            description: The cluster is close to using up all CPU resources. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} idle cpu cores accross cluster.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
+            syn_component: openshift4-monitoring
+          expr: sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance)
+            group_left label_replace(kube_node_role{role="app"}, "instance", "$1",
+            "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="cpu"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-MemoryCapacity
+      rules:
+        - alert: SYN_ClusterLowOnMemory
+          annotations:
+            description: The cluster is close to using all of its memory. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} free memory on Worker Nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
+            syn_component: openshift4-monitoring
+          expr: sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"},
+            "instance", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="memory"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-PodCapacity
+      rules:
+        - alert: SYN_TooManyPods
+          annotations:
+            description: The cluster is close to the limit of running pods. The cluster
+              might not be able to handle node failures and might not be able to start
+              new pods. Consider adding new nodes.
+            message: Only {{ $value }} more pods can be started.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_capacity{resource="pods"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"},
+            "node", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-ResourceRequests
+      rules:
+        - alert: SYN_TooMuchCPURequested
+          annotations:
+            description: The cluster is close to assigning all CPU resources to running
+              pods. The cluster might not be able to handle node failures and might
+              soon not be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} cpu cores left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            < 1.000000 * max((kube_node_status_allocatable{resource="cpu"}) * on(node)
+            group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_TooMuchMemoryRequested
+          annotations:
+            description: The cluster is close to assigning all memory to running pods.
+              The cluster might not be able to handle node failures and might not
+              be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} memory left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            < 1.000000 * max((kube_node_status_allocatable{resource="memory"}) * on(node)
+            group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-UnusedCapacity
+      rules:
+        - alert: SYN_ClusterHasUnusedNodes
+          annotations:
+            description: The cluster has {{ $value }} unused nodes. Consider removing
+              unused nodes.
+            message: Cluster has unused nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
+            syn_component: openshift4-monitoring
+          expr: "min(\n  (\n    label_replace(\n      (sum(kube_node_status_capacity{resource=\"\
+            pods\"} * on(node) group_left label_replace(kube_node_role{role=\"app\"\
+            }, \"node\", \"$1\", \"node\", \"(.+)\")) - sum(kubelet_running_pods *\
+            \ on(node) group_left label_replace(kube_node_role{role=\"app\"}, \"node\"\
+            , \"$1\", \"node\", \"(.+)\"))) / max((kube_node_status_capacity{resource=\"\
+            pods\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"pods\", \"\", \"\")\n  ) or (\n    label_replace(\n    \
+            \  (sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left\
+            \ label_replace(kube_node_role{role=\"app\"}, \"node\", \"$1\", \"node\"\
+            , \"(.+)\")) - sum(kube_pod_resource_request{resource=\"memory\"} * on(node)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"node\", \"\
+            $1\", \"node\", \"(.+)\"))) / max((kube_node_status_allocatable{resource=\"\
+            memory\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    ,\
+            \ \"resource\", \"requested_memory\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      (sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"node\", \"\
+            $1\", \"node\", \"(.+)\")) - sum(kube_pod_resource_request{resource=\"\
+            cpu\"} * on(node) group_left label_replace(kube_node_role{role=\"app\"\
+            }, \"node\", \"$1\", \"node\", \"(.+)\"))) / max((kube_node_status_allocatable{resource=\"\
+            cpu\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"requested_cpu\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role=\"\
+            app\"}, \"instance\", \"$1\", \"node\", \"(.+)\")) / max((kube_node_status_capacity{resource=\"\
+            memory\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    ,\
+            \ \"resource\", \"memory\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      sum(rate(node_cpu_seconds_total{mode=\"idle\"}[15m]) * on(instance)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"instance\"\
+            , \"$1\", \"node\", \"(.+)\")) / max((kube_node_status_capacity{resource=\"\
+            cpu\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"cpu\", \"\", \"\")\n  )\n) > 4.000000\n"
+          for: 8h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/es-operator-rules/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/es-operator-rules/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -25,7 +25,7 @@ metadata:
   name: silence
   namespace: openshift-monitoring
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations: {}

--- a/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
+++ b/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
@@ -1,0 +1,152 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    syn_component: openshift4-monitoring
+  labels:
+    name: capacity
+  name: capacity
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: syn-CpuCapacity
+      rules:
+        - alert: SYN_ClusterCpuUsageHigh
+          annotations:
+            description: The cluster is close to using up all CPU resources. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} idle cpu cores accross cluster.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
+            syn_component: openshift4-monitoring
+          expr: sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance)
+            group_left label_replace(kube_node_role{role="app"}, "instance", "$1",
+            "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="cpu"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-MemoryCapacity
+      rules:
+        - alert: SYN_ClusterLowOnMemory
+          annotations:
+            description: The cluster is close to using all of its memory. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} free memory on Worker Nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
+            syn_component: openshift4-monitoring
+          expr: sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"},
+            "instance", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="memory"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-PodCapacity
+      rules:
+        - alert: SYN_TooManyPods
+          annotations:
+            description: The cluster is close to the limit of running pods. The cluster
+              might not be able to handle node failures and might not be able to start
+              new pods. Consider adding new nodes.
+            message: Only {{ $value }} more pods can be started.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_capacity{resource="pods"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"},
+            "node", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-ResourceRequests
+      rules:
+        - alert: SYN_TooMuchCPURequested
+          annotations:
+            description: The cluster is close to assigning all CPU resources to running
+              pods. The cluster might not be able to handle node failures and might
+              soon not be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} cpu cores left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            < 1.000000 * max((kube_node_status_allocatable{resource="cpu"}) * on(node)
+            group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_TooMuchMemoryRequested
+          annotations:
+            description: The cluster is close to assigning all memory to running pods.
+              The cluster might not be able to handle node failures and might not
+              be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} memory left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            < 1.000000 * max((kube_node_status_allocatable{resource="memory"}) * on(node)
+            group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-UnusedCapacity
+      rules:
+        - alert: SYN_ClusterHasUnusedNodes
+          annotations:
+            description: The cluster has {{ $value }} unused nodes. Consider removing
+              unused nodes.
+            message: Cluster has unused nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
+            syn_component: openshift4-monitoring
+          expr: "min(\n  (\n    label_replace(\n      (sum(kube_node_status_capacity{resource=\"\
+            pods\"} * on(node) group_left label_replace(kube_node_role{role=\"app\"\
+            }, \"node\", \"$1\", \"node\", \"(.+)\")) - sum(kubelet_running_pods *\
+            \ on(node) group_left label_replace(kube_node_role{role=\"app\"}, \"node\"\
+            , \"$1\", \"node\", \"(.+)\"))) / max((kube_node_status_capacity{resource=\"\
+            pods\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"pods\", \"\", \"\")\n  ) or (\n    label_replace(\n    \
+            \  (sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left\
+            \ label_replace(kube_node_role{role=\"app\"}, \"node\", \"$1\", \"node\"\
+            , \"(.+)\")) - sum(kube_pod_resource_request{resource=\"memory\"} * on(node)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"node\", \"\
+            $1\", \"node\", \"(.+)\"))) / max((kube_node_status_allocatable{resource=\"\
+            memory\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    ,\
+            \ \"resource\", \"requested_memory\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      (sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"node\", \"\
+            $1\", \"node\", \"(.+)\")) - sum(kube_pod_resource_request{resource=\"\
+            cpu\"} * on(node) group_left label_replace(kube_node_role{role=\"app\"\
+            }, \"node\", \"$1\", \"node\", \"(.+)\"))) / max((kube_node_status_allocatable{resource=\"\
+            cpu\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"requested_cpu\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role=\"\
+            app\"}, \"instance\", \"$1\", \"node\", \"(.+)\")) / max((kube_node_status_capacity{resource=\"\
+            memory\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    ,\
+            \ \"resource\", \"memory\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      sum(rate(node_cpu_seconds_total{mode=\"idle\"}[15m]) * on(instance)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"instance\"\
+            , \"$1\", \"node\", \"(.+)\")) / max((kube_node_status_capacity{resource=\"\
+            cpu\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"cpu\", \"\", \"\")\n  )\n) > 4.000000\n"
+          for: 8h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -25,7 +25,7 @@ metadata:
   name: silence
   namespace: openshift-monitoring
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations: {}

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
@@ -1,0 +1,152 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    syn_component: openshift4-monitoring
+  labels:
+    name: capacity
+  name: capacity
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: syn-CpuCapacity
+      rules:
+        - alert: SYN_ClusterCpuUsageHigh
+          annotations:
+            description: The cluster is close to using up all CPU resources. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} idle cpu cores accross cluster.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
+            syn_component: openshift4-monitoring
+          expr: sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance)
+            group_left label_replace(kube_node_role{role="app"}, "instance", "$1",
+            "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="cpu"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-MemoryCapacity
+      rules:
+        - alert: SYN_ClusterLowOnMemory
+          annotations:
+            description: The cluster is close to using all of its memory. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} free memory on Worker Nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
+            syn_component: openshift4-monitoring
+          expr: sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"},
+            "instance", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="memory"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-PodCapacity
+      rules:
+        - alert: SYN_TooManyPods
+          annotations:
+            description: The cluster is close to the limit of running pods. The cluster
+              might not be able to handle node failures and might not be able to start
+              new pods. Consider adding new nodes.
+            message: Only {{ $value }} more pods can be started.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_capacity{resource="pods"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"},
+            "node", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-ResourceRequests
+      rules:
+        - alert: SYN_TooMuchCPURequested
+          annotations:
+            description: The cluster is close to assigning all CPU resources to running
+              pods. The cluster might not be able to handle node failures and might
+              soon not be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} cpu cores left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            < 1.000000 * max((kube_node_status_allocatable{resource="cpu"}) * on(node)
+            group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_TooMuchMemoryRequested
+          annotations:
+            description: The cluster is close to assigning all memory to running pods.
+              The cluster might not be able to handle node failures and might not
+              be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} memory left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            < 1.000000 * max((kube_node_status_allocatable{resource="memory"}) * on(node)
+            group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-UnusedCapacity
+      rules:
+        - alert: SYN_ClusterHasUnusedNodes
+          annotations:
+            description: The cluster has {{ $value }} unused nodes. Consider removing
+              unused nodes.
+            message: Cluster has unused nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
+            syn_component: openshift4-monitoring
+          expr: "min(\n  (\n    label_replace(\n      (sum(kube_node_status_capacity{resource=\"\
+            pods\"} * on(node) group_left label_replace(kube_node_role{role=\"app\"\
+            }, \"node\", \"$1\", \"node\", \"(.+)\")) - sum(kubelet_running_pods *\
+            \ on(node) group_left label_replace(kube_node_role{role=\"app\"}, \"node\"\
+            , \"$1\", \"node\", \"(.+)\"))) / max((kube_node_status_capacity{resource=\"\
+            pods\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"pods\", \"\", \"\")\n  ) or (\n    label_replace(\n    \
+            \  (sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left\
+            \ label_replace(kube_node_role{role=\"app\"}, \"node\", \"$1\", \"node\"\
+            , \"(.+)\")) - sum(kube_pod_resource_request{resource=\"memory\"} * on(node)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"node\", \"\
+            $1\", \"node\", \"(.+)\"))) / max((kube_node_status_allocatable{resource=\"\
+            memory\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    ,\
+            \ \"resource\", \"requested_memory\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      (sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"node\", \"\
+            $1\", \"node\", \"(.+)\")) - sum(kube_pod_resource_request{resource=\"\
+            cpu\"} * on(node) group_left label_replace(kube_node_role{role=\"app\"\
+            }, \"node\", \"$1\", \"node\", \"(.+)\"))) / max((kube_node_status_allocatable{resource=\"\
+            cpu\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"requested_cpu\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role=\"\
+            app\"}, \"instance\", \"$1\", \"node\", \"(.+)\")) / max((kube_node_status_capacity{resource=\"\
+            memory\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    ,\
+            \ \"resource\", \"memory\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      sum(rate(node_cpu_seconds_total{mode=\"idle\"}[15m]) * on(instance)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"instance\"\
+            , \"$1\", \"node\", \"(.+)\")) / max((kube_node_status_capacity{resource=\"\
+            cpu\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"cpu\", \"\", \"\")\n  )\n) > 4.000000\n"
+          for: 8h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -25,7 +25,7 @@ metadata:
   name: silence
   namespace: openshift-monitoring
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations: {}

--- a/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
+++ b/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
@@ -1,0 +1,152 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    syn_component: openshift4-monitoring
+  labels:
+    name: capacity
+  name: capacity
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: syn-CpuCapacity
+      rules:
+        - alert: SYN_ClusterCpuUsageHigh
+          annotations:
+            description: The cluster is close to using up all CPU resources. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} idle cpu cores accross cluster.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
+            syn_component: openshift4-monitoring
+          expr: sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance)
+            group_left label_replace(kube_node_role{role="app"}, "instance", "$1",
+            "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="cpu"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-MemoryCapacity
+      rules:
+        - alert: SYN_ClusterLowOnMemory
+          annotations:
+            description: The cluster is close to using all of its memory. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} free memory on Worker Nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
+            syn_component: openshift4-monitoring
+          expr: sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"},
+            "instance", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="memory"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-PodCapacity
+      rules:
+        - alert: SYN_TooManyPods
+          annotations:
+            description: The cluster is close to the limit of running pods. The cluster
+              might not be able to handle node failures and might not be able to start
+              new pods. Consider adding new nodes.
+            message: Only {{ $value }} more pods can be started.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_capacity{resource="pods"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"},
+            "node", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-ResourceRequests
+      rules:
+        - alert: SYN_TooMuchCPURequested
+          annotations:
+            description: The cluster is close to assigning all CPU resources to running
+              pods. The cluster might not be able to handle node failures and might
+              soon not be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} cpu cores left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            < 1.000000 * max((kube_node_status_allocatable{resource="cpu"}) * on(node)
+            group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_TooMuchMemoryRequested
+          annotations:
+            description: The cluster is close to assigning all memory to running pods.
+              The cluster might not be able to handle node failures and might not
+              be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} memory left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            < 1.000000 * max((kube_node_status_allocatable{resource="memory"}) * on(node)
+            group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-UnusedCapacity
+      rules:
+        - alert: SYN_ClusterHasUnusedNodes
+          annotations:
+            description: The cluster has {{ $value }} unused nodes. Consider removing
+              unused nodes.
+            message: Cluster has unused nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
+            syn_component: openshift4-monitoring
+          expr: "min(\n  (\n    label_replace(\n      (sum(kube_node_status_capacity{resource=\"\
+            pods\"} * on(node) group_left label_replace(kube_node_role{role=\"app\"\
+            }, \"node\", \"$1\", \"node\", \"(.+)\")) - sum(kubelet_running_pods *\
+            \ on(node) group_left label_replace(kube_node_role{role=\"app\"}, \"node\"\
+            , \"$1\", \"node\", \"(.+)\"))) / max((kube_node_status_capacity{resource=\"\
+            pods\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"pods\", \"\", \"\")\n  ) or (\n    label_replace(\n    \
+            \  (sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left\
+            \ label_replace(kube_node_role{role=\"app\"}, \"node\", \"$1\", \"node\"\
+            , \"(.+)\")) - sum(kube_pod_resource_request{resource=\"memory\"} * on(node)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"node\", \"\
+            $1\", \"node\", \"(.+)\"))) / max((kube_node_status_allocatable{resource=\"\
+            memory\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    ,\
+            \ \"resource\", \"requested_memory\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      (sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"node\", \"\
+            $1\", \"node\", \"(.+)\")) - sum(kube_pod_resource_request{resource=\"\
+            cpu\"} * on(node) group_left label_replace(kube_node_role{role=\"app\"\
+            }, \"node\", \"$1\", \"node\", \"(.+)\"))) / max((kube_node_status_allocatable{resource=\"\
+            cpu\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"requested_cpu\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role=\"\
+            app\"}, \"instance\", \"$1\", \"node\", \"(.+)\")) / max((kube_node_status_capacity{resource=\"\
+            memory\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    ,\
+            \ \"resource\", \"memory\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      sum(rate(node_cpu_seconds_total{mode=\"idle\"}[15m]) * on(instance)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"instance\"\
+            , \"$1\", \"node\", \"(.+)\")) / max((kube_node_status_capacity{resource=\"\
+            cpu\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"cpu\", \"\", \"\")\n  )\n) > 4.000000\n"
+          for: 8h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -25,7 +25,7 @@ metadata:
   name: silence
   namespace: openshift-monitoring
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations: {}

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
@@ -1,0 +1,152 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    syn_component: openshift4-monitoring
+  labels:
+    name: capacity
+  name: capacity
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: syn-CpuCapacity
+      rules:
+        - alert: SYN_ClusterCpuUsageHigh
+          annotations:
+            description: The cluster is close to using up all CPU resources. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} idle cpu cores accross cluster.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
+            syn_component: openshift4-monitoring
+          expr: sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance)
+            group_left label_replace(kube_node_role{role="app"}, "instance", "$1",
+            "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="cpu"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-MemoryCapacity
+      rules:
+        - alert: SYN_ClusterLowOnMemory
+          annotations:
+            description: The cluster is close to using all of its memory. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} free memory on Worker Nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
+            syn_component: openshift4-monitoring
+          expr: sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"},
+            "instance", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="memory"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-PodCapacity
+      rules:
+        - alert: SYN_TooManyPods
+          annotations:
+            description: The cluster is close to the limit of running pods. The cluster
+              might not be able to handle node failures and might not be able to start
+              new pods. Consider adding new nodes.
+            message: Only {{ $value }} more pods can be started.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_capacity{resource="pods"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"},
+            "node", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-ResourceRequests
+      rules:
+        - alert: SYN_TooMuchCPURequested
+          annotations:
+            description: The cluster is close to assigning all CPU resources to running
+              pods. The cluster might not be able to handle node failures and might
+              soon not be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} cpu cores left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            < 1.000000 * max((kube_node_status_allocatable{resource="cpu"}) * on(node)
+            group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_TooMuchMemoryRequested
+          annotations:
+            description: The cluster is close to assigning all memory to running pods.
+              The cluster might not be able to handle node failures and might not
+              be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} memory left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            < 1.000000 * max((kube_node_status_allocatable{resource="memory"}) * on(node)
+            group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-UnusedCapacity
+      rules:
+        - alert: SYN_ClusterHasUnusedNodes
+          annotations:
+            description: The cluster has {{ $value }} unused nodes. Consider removing
+              unused nodes.
+            message: Cluster has unused nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
+            syn_component: openshift4-monitoring
+          expr: "min(\n  (\n    label_replace(\n      (sum(kube_node_status_capacity{resource=\"\
+            pods\"} * on(node) group_left label_replace(kube_node_role{role=\"app\"\
+            }, \"node\", \"$1\", \"node\", \"(.+)\")) - sum(kubelet_running_pods *\
+            \ on(node) group_left label_replace(kube_node_role{role=\"app\"}, \"node\"\
+            , \"$1\", \"node\", \"(.+)\"))) / max((kube_node_status_capacity{resource=\"\
+            pods\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"pods\", \"\", \"\")\n  ) or (\n    label_replace(\n    \
+            \  (sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left\
+            \ label_replace(kube_node_role{role=\"app\"}, \"node\", \"$1\", \"node\"\
+            , \"(.+)\")) - sum(kube_pod_resource_request{resource=\"memory\"} * on(node)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"node\", \"\
+            $1\", \"node\", \"(.+)\"))) / max((kube_node_status_allocatable{resource=\"\
+            memory\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    ,\
+            \ \"resource\", \"requested_memory\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      (sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"node\", \"\
+            $1\", \"node\", \"(.+)\")) - sum(kube_pod_resource_request{resource=\"\
+            cpu\"} * on(node) group_left label_replace(kube_node_role{role=\"app\"\
+            }, \"node\", \"$1\", \"node\", \"(.+)\"))) / max((kube_node_status_allocatable{resource=\"\
+            cpu\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"requested_cpu\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role=\"\
+            app\"}, \"instance\", \"$1\", \"node\", \"(.+)\")) / max((kube_node_status_capacity{resource=\"\
+            memory\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    ,\
+            \ \"resource\", \"memory\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      sum(rate(node_cpu_seconds_total{mode=\"idle\"}[15m]) * on(instance)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"instance\"\
+            , \"$1\", \"node\", \"(.+)\")) / max((kube_node_status_capacity{resource=\"\
+            cpu\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"cpu\", \"\", \"\")\n  )\n) > 4.000000\n"
+          for: 8h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -25,7 +25,7 @@ metadata:
   name: silence
   namespace: openshift-monitoring
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations: {}

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
@@ -1,0 +1,152 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    syn_component: openshift4-monitoring
+  labels:
+    name: capacity
+  name: capacity
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: syn-CpuCapacity
+      rules:
+        - alert: SYN_ClusterCpuUsageHigh
+          annotations:
+            description: The cluster is close to using up all CPU resources. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} idle cpu cores accross cluster.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
+            syn_component: openshift4-monitoring
+          expr: sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance)
+            group_left label_replace(kube_node_role{role="app"}, "instance", "$1",
+            "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="cpu"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-MemoryCapacity
+      rules:
+        - alert: SYN_ClusterLowOnMemory
+          annotations:
+            description: The cluster is close to using all of its memory. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} free memory on Worker Nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
+            syn_component: openshift4-monitoring
+          expr: sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"},
+            "instance", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="memory"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-PodCapacity
+      rules:
+        - alert: SYN_TooManyPods
+          annotations:
+            description: The cluster is close to the limit of running pods. The cluster
+              might not be able to handle node failures and might not be able to start
+              new pods. Consider adding new nodes.
+            message: Only {{ $value }} more pods can be started.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_capacity{resource="pods"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"},
+            "node", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
+            * on(node) group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-ResourceRequests
+      rules:
+        - alert: SYN_TooMuchCPURequested
+          annotations:
+            description: The cluster is close to assigning all CPU resources to running
+              pods. The cluster might not be able to handle node failures and might
+              soon not be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} cpu cores left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            < 1.000000 * max((kube_node_status_allocatable{resource="cpu"}) * on(node)
+            group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_TooMuchMemoryRequested
+          annotations:
+            description: The cluster is close to assigning all memory to running pods.
+              The cluster might not be able to handle node failures and might not
+              be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} memory left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
+            syn_component: openshift4-monitoring
+          expr: sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left
+            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
+            < 1.000000 * max((kube_node_status_allocatable{resource="memory"}) * on(node)
+            group_left kube_node_role{role="app"})
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-UnusedCapacity
+      rules:
+        - alert: SYN_ClusterHasUnusedNodes
+          annotations:
+            description: The cluster has {{ $value }} unused nodes. Consider removing
+              unused nodes.
+            message: Cluster has unused nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
+            syn_component: openshift4-monitoring
+          expr: "min(\n  (\n    label_replace(\n      (sum(kube_node_status_capacity{resource=\"\
+            pods\"} * on(node) group_left label_replace(kube_node_role{role=\"app\"\
+            }, \"node\", \"$1\", \"node\", \"(.+)\")) - sum(kubelet_running_pods *\
+            \ on(node) group_left label_replace(kube_node_role{role=\"app\"}, \"node\"\
+            , \"$1\", \"node\", \"(.+)\"))) / max((kube_node_status_capacity{resource=\"\
+            pods\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"pods\", \"\", \"\")\n  ) or (\n    label_replace(\n    \
+            \  (sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left\
+            \ label_replace(kube_node_role{role=\"app\"}, \"node\", \"$1\", \"node\"\
+            , \"(.+)\")) - sum(kube_pod_resource_request{resource=\"memory\"} * on(node)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"node\", \"\
+            $1\", \"node\", \"(.+)\"))) / max((kube_node_status_allocatable{resource=\"\
+            memory\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    ,\
+            \ \"resource\", \"requested_memory\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      (sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"node\", \"\
+            $1\", \"node\", \"(.+)\")) - sum(kube_pod_resource_request{resource=\"\
+            cpu\"} * on(node) group_left label_replace(kube_node_role{role=\"app\"\
+            }, \"node\", \"$1\", \"node\", \"(.+)\"))) / max((kube_node_status_allocatable{resource=\"\
+            cpu\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"requested_cpu\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role=\"\
+            app\"}, \"instance\", \"$1\", \"node\", \"(.+)\")) / max((kube_node_status_capacity{resource=\"\
+            memory\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    ,\
+            \ \"resource\", \"memory\", \"\", \"\")\n  ) or (\n    label_replace(\n\
+            \      sum(rate(node_cpu_seconds_total{mode=\"idle\"}[15m]) * on(instance)\
+            \ group_left label_replace(kube_node_role{role=\"app\"}, \"instance\"\
+            , \"$1\", \"node\", \"(.+)\")) / max((kube_node_status_capacity{resource=\"\
+            cpu\"}) * on(node) group_left kube_node_role{role=\"app\"})\n    , \"\
+            resource\", \"cpu\", \"\", \"\")\n  )\n) > 4.000000\n"
+          for: 8h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -25,7 +25,7 @@ metadata:
   name: silence
   namespace: openshift-monitoring
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations: {}


### PR DESCRIPTION


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
