### PR TITLE
Add: Support for cortex-tenant-ns-label

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -322,3 +322,12 @@ parameters:
       instance: null
 
     secrets: {}
+
+    cortex_tenant_ns_label:
+      enabled: false
+      requests:
+        cpu: '500m'
+        memory: '256Mi'
+      limits:
+        cpu: '5'
+        memory: '256Mi'

--- a/component/cortex-tenant-ns-label.jsonnet
+++ b/component/cortex-tenant-ns-label.jsonnet
@@ -1,0 +1,141 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_monitoring;
+
+local app_name = 'cortex-tenant-ns-label';
+local namespace_name = 'syn-cortex-tenant-ns-label';
+
+local namespace_meta = {
+  metadata+: {
+    namespace: namespace_name,
+  },
+};
+
+local namespace = kube.Namespace(namespace_name);
+
+local secret = kube.Secret(app_name) + namespace_meta {
+  stringData: {
+    CONFIG: params.cortex_tenant_ns_label.config,
+  },
+};
+
+
+local deployment = kube.Deployment('cortex-tenant-ns-label') + namespace_meta {
+  spec+: {
+    template+: {
+      metadata+: {
+        labels+: {
+          app: 'cortex-tenant-ns-label',
+        },
+      },
+      spec+: {
+        containers_:: {
+          [app_name]: kube.Container(app_name) {
+            image: 'ghcr.io/vshn/cortex-tenant-ns-label:latest',
+            resources: {
+              limits: {
+                cpu: params.cortex_tenant_ns_label.limits.cpu,
+                memory: params.cortex_tenant_ns_label.limits.memory,
+              },
+              requests: {
+                cpu: params.cortex_tenant_ns_label.requests.cpu,
+                memory: params.cortex_tenant_ns_label.requests.memory,
+              },
+            },
+            ports_:: {
+              http: { containerPort: 8080 },
+            },
+            livenessProbe: {
+              httpGet: {
+                path: '/alive',
+                port: 8080,
+              },
+              initialDelaySeconds: 30,
+              periodSeconds: 30,
+            },
+            envFrom: [
+              {
+                secretRef: {
+                  name: secret.metadata.name,
+                },
+              },
+            ],
+          },
+        },
+        serviceAccountName+: app_name,
+      },
+    },
+  },
+};
+
+local service = kube.Service('cortex-tenant-ns-label') + namespace_meta {
+  target_pod:: deployment.spec.template,
+  target_container_name:: app_name,
+};
+
+local service_account = kube.ServiceAccount(app_name) + namespace_meta {
+};
+
+local cluster_role = kube.ClusterRole(app_name + ':namespace-reader') {
+  rules: [
+    { apiGroups: [ '' ], resources: [ 'namespaces' ], verbs: [ 'get', 'list' ] },
+  ],
+};
+
+local cluster_role_binding = kube.ClusterRoleBinding(app_name + '-namespace-reader') {
+  subjects_: [ service_account ],
+  roleRef_: cluster_role,
+};
+
+local network_policies_cluster_metrics = [
+  kube.NetworkPolicy('allow-from-openshift-monitoring') + namespace_meta {
+    spec: {
+      ingress: [ {
+        from: [
+          { podSelector: { matchLabels: { prometheus: 'k8s' } } },
+          { namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': 'openshift-monitoring' } } },
+        ],
+        ports: [ { port: 8080, protocol: 'TCP' } ],
+      } ],
+      podSelector: {
+        matchLabels: {
+          name: 'cortex-tenant-ns-label',
+        },
+      },
+      policyTypes: [ 'Ingress' ],
+    },
+  },
+];
+
+local network_policies_user_metrics = [
+  if params.enableUserWorkload then
+    kube.NetworkPolicy('allow-from-openshift-user-workload-monitoring') + namespace_meta {
+      spec: {
+        ingress: [ {
+          from: [
+            { podSelector: { matchLabels: { prometheus: 'k8s' } } },
+            { namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': 'openshift-user-workload-monitoring' } } },
+          ],
+          ports: [ { port: 8080, protocol: 'TCP' } ],
+        } ],
+        podSelector: {
+          matchLabels: {
+            name: 'cortex-tenant-ns-label',
+          },
+        },
+        policyTypes: [ 'Ingress' ],
+      },
+    },
+];
+
+[
+  cluster_role,
+  namespace,
+  service_account,
+  cluster_role_binding,
+  deployment,
+  service,
+  secret,
+] + network_policies_cluster_metrics + network_policies_user_metrics

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -90,6 +90,7 @@ local ns_patch =
   rbac: import 'rbac.libsonnet',
   prometheus_rules: rules,
   silence: import 'silence.jsonnet',
+  [if params.cortex_tenant_ns_label.enabled then 'cortex_tenant_ns_label']: import 'cortex-tenant-ns-label.jsonnet',
   [if params.capacityAlerts.enabled then 'capacity_rules']: capacity.rules,
 } + {
   [group_name + '_rules']: prom.PrometheusRule(group_name) {

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -538,3 +538,69 @@ default:: `{}`
 A dict of secrets to create in the namespace.
 The key is the name of the secret, the value is the content of the secret.
 The value must be a dict with a key `stringData` which is a dict of key/value pairs to add to the secret.
+
+== `cortex_tenant_ns_label`
+
+[horizontal]
+type:: dict
+
+Parameters to configure the cortex-tenant-ns-label reverse proxy.
+
+=== `enabled`
+
+[horizontal]
+type:: boolean
+default:: `false`
+
+Enable or disable the cortex-tenant-ns-label reverse proxy.
+
+=== `requests`
+
+[horizontal]
+type:: dict
+default::
++
+[source,yaml]
+----
+cpu: '500m'
+memory: '256Mi'
+----
+
+Configure the reserved resources for the cortex-tenant-ns-label reverse proxy.
+
+=== `limits`
+
+[horizontal]
+type:: dict
+default::
++
+[source,yaml]
+----
+cpu: '5'
+memory: '256Mi'
+----
+
+Configure the maximum resources for the cortex-tenant-ns-label reverse proxy.
+
+=== `config`
+
+[horizontal]
+type:: string
+default:: ``
+example::
++
+[source,yaml]
+----
+listen: 0.0.0.0:8080
+target: https://metrics-receive.appuio.net/api/v1/push
+log_level: warn
+auth:
+  egress:
+    username: ?{vaultkv:__shared__/__shared__/metrics-receive-appuio-net-remote-write/username}
+    password: ?{vaultkv:__shared__/__shared__/metrics-receive-appuio-net-remote-write/password}
+  namespace:
+    tenant_label: 'appuio.io/organization'
+----
+
+Configure the cortex-tenant-ns-label reverse proxy. See https://github.com/vshn/cortex-tenant-ns-label for more details.
+


### PR DESCRIPTION
Add support for the [cortex-tenant-ns-label](https://github.com/vshn/cortex-tenant-ns-label/) reverse proxy server.

The purpose of this proxy is to assign the correct tenant to metrics by injecting the X-Scope-OrgID header into Prometheus remote writes. For this to work the proxy has to look at the metric's 'namespace' label, get the namespace metadata from k8s, and read the configured namespace label. It also has to split up batched metrics into multiple requests.

This proxy is only useful in multi-tenant clusters. In single-tenant clusters the X-Scope-OrgID header can be configured directly in Prometheus as it is the same for all writes.

This only sets up the proxy and required network policies. It does not configure Prometheus to actually use the proxy; this is not in the scope of this change. 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.