### PR TITLE
Add support for grouping capacity alerts by node label

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "template": "https://github.com/projectsyn/commodore-component-template.git",
-  "commit": "956a1b342ed680b02b1fb1b646dc5d4c640e2028",
+  "commit": "cfd150bd41deaa0ad10d522ec5fd0abafed65800",
   "checkout": "main",
   "context": {
     "cookiecutter": {
       "name": "OpenShift4 Monitoring",
       "slug": "openshift4-monitoring",
       "parameter_key": "openshift4_monitoring",
-      "test_cases": "capacity-alerts release-4.9 release-4.10 release-4.11 remote-write user-workload-monitoring es-operator-rules",
+      "test_cases": "capacity-alerts release-4.9 release-4.10 release-4.11 remote-write user-workload-monitoring es-operator-rules capacity-alerts-with-node-labels",
       "add_lib": "y",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,7 @@ jobs:
           - remote-write
           - user-workload-monitoring
           - es-operator-rules
+          - capacity-alerts-with-node-labels
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -60,6 +61,7 @@ jobs:
           - remote-write
           - user-workload-monitoring
           - es-operator-rules
+          - capacity-alerts-with-node-labels
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= capacity-alerts
-test_instances = tests/capacity-alerts.yml tests/release-4.9.yml tests/release-4.10.yml tests/release-4.11.yml tests/remote-write.yml tests/user-workload-monitoring.yml tests/es-operator-rules.yml
+test_instances = tests/capacity-alerts.yml tests/release-4.9.yml tests/release-4.10.yml tests/release-4.11.yml tests/remote-write.yml tests/user-workload-monitoring.yml tests/es-operator-rules.yml tests/capacity-alerts-with-node-labels.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -158,6 +158,7 @@ parameters:
 
     capacityAlerts:
       enabled: true
+      groupByNodeLabels: []
       groups:
         PodCapacity:
           rules:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -411,15 +411,16 @@ Example:
 ---
 capacityAlerts:
   enabled: true <1>
+  groupByNodeLabels: [] <2>
   groups:
     PodCapacity:
       rules:
         TooManyPods:
           annotations:
-            message: 'The number of pods is too damn high' <2>
-          for: 3h <3>
+            message: 'The number of pods is too damn high' <3>
+          for: 3h <4>
         ExpectTooManyPods:
-          expr: <4>
+          expr: <5>
             range: '2d'
             predict: '5*24*60*60'
 
@@ -428,25 +429,26 @@ capacityAlerts:
         TooMuchMemoryRequested:
           enabled: true
           expr:
-            raw: sum(kube_pod_resource_request{resource="memory"}) > 9000*1024*1024*1024 <5>
+            raw: sum(kube_pod_resource_request{resource="memory"}) > 9000*1024*1024*1024 <6>
     CpuCapacity:
       rules:
         ClusterCpuUsageHigh:
-          enabled: false <6>
+          enabled: false <7>
         ExpectClusterCpuUsageHigh:
-          enabled: false <6>
+          enabled: false <7>
     UnusedCapacity:
       rules:
         ClusterHasUnusedNodes:
-          enabled: false <7>
+          enabled: false <8>
 ---
 <1> Enables capacity alerts
-<2> Changes the alert message for the pod capacity alert
-<3> Only alerts for pod capacity if it fires for 3 hours
-<4> Change the pod count prediction to look at the last two days and predict the value in five days
-<5> Completely overrides the default alert rule and alerts if the total memory request is over 9000 GB
-<6> Disables both CPU capacity alert rules
-<7> Disables alert if the cluster has unused nodes.
+<2> List of node labels (as they show up in the `kube_node_labels` metric) by which alerts are grouped
+<3> Changes the alert message for the pod capacity alert
+<4> Only alerts for pod capacity if it fires for 3 hours
+<5> Change the pod count prediction to look at the last two days and predict the value in five days
+<6> Completely overrides the default alert rule and alerts if the total memory request is over 9000 GB
+<7> Disables both CPU capacity alert rules
+<8> Disables alert if the cluster has unused nodes.
 
 
 == `rules`

--- a/tests/capacity-alerts-with-node-labels.yml
+++ b/tests/capacity-alerts-with-node-labels.yml
@@ -1,0 +1,27 @@
+applications:
+  - prometheus
+
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-resource-locker/v2.0.1/lib/resource-locker.libjsonnet
+        output_path: vendor/lib/resource-locker.libjsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-prometheus/master/lib/prometheus.libsonnet
+        output_path: vendor/lib/prometheus.libsonnet
+
+  resource_locker:
+    namespace: syn-resource-locker
+
+  openshift4_monitoring:
+    manifests_version: release-4.10
+
+    capacityAlerts:
+      enabled: true
+      groupByNodeLabels:
+        - label_appuio_io_node_class
+        - label_kubernetes_io_os
+
+  prometheus:
+    defaultInstance: infra

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/00_namespace_labels.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/00_namespace_labels.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: openshift-monitoring-manager
+  name: openshift-monitoring-manager
+  namespace: syn-resource-locker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    name: syn-resource-locker-openshift-monitoring-manager
+  name: syn-resource-locker-openshift-monitoring-manager
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    name: syn-resource-locker-openshift-monitoring-manager
+  name: syn-resource-locker-openshift-monitoring-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-resource-locker-openshift-monitoring-manager
+subjects:
+  - kind: ServiceAccount
+    name: openshift-monitoring-manager
+    namespace: syn-resource-locker
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: ResourceLocker
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: openshift-monitoring
+  name: openshift-monitoring
+  namespace: syn-resource-locker
+spec:
+  patches:
+    - id: patch1
+      patchTemplate: |-
+        "metadata":
+          "labels":
+            "network.openshift.io/policy-group": "monitoring"
+      patchType: application/strategic-merge-patch+json
+      targetObjectRef:
+        apiVersion: v1
+        kind: Namespace
+        name: openshift-monitoring
+  serviceAccountRef:
+    name: openshift-monitoring-manager

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/02_aggregated_clusterroles.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/02_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-openshift4-monitoring-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-openshift4-monitoring-cluster-reader
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_alertmanager_config.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_alertmanager_config.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-main
+  name: alertmanager-main
+  namespace: openshift-monitoring
+stringData:
+  alertmanager.yaml: |-
+    "inhibit_rules":
+    - "equal":
+      - "namespace"
+      - "alertname"
+      "source_match":
+        "severity": "critical"
+      "target_match_re":
+        "severity": "warning|info"
+    - "equal":
+      - "namespace"
+      - "alertname"
+      "source_match":
+        "severity": "warning"
+      "target_match_re":
+        "severity": "info"
+    "route":
+      "group_interval": "5s"
+      "group_wait": "0s"
+      "repeat_interval": "10m"
+type: Opaque

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+data:
+  config.yaml: |-
+    "alertmanagerMain":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+      "volumeClaimTemplate":
+        "spec":
+          "resources":
+            "requests":
+              "storage": "2Gi"
+    "enableUserWorkload": true
+    "grafana":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "k8sPrometheusAdapter":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "kubeStateMetrics":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "openshiftStateMetrics":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "prometheusK8s":
+      "externalLabels":
+        "cluster_id": "c-green-test-1234"
+        "tenant_id": "t-silent-test-1234"
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+      "remoteWrite": []
+      "retention": "8d"
+      "volumeClaimTemplate":
+        "spec":
+          "resources":
+            "requests":
+              "storage": "50Gi"
+    "prometheusOperator":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "telemeterClient":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "thanosQuerier":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-monitoring-config
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+data:
+  config.yaml: |-
+    "alertmanager":
+      "enableAlertmanagerConfig": true
+      "enabled": true
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+      "volumeClaimTemplate":
+        "spec":
+          "resources":
+            "requests":
+              "storage": "2Gi"
+    "prometheus":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+      "retention": "8d"
+      "volumeClaimTemplate":
+        "spec":
+          "resources":
+            "requests":
+              "storage": "50Gi"
+    "prometheusOperator":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "thanosRuler":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: user-workload-monitoring-config
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/90_syn_monitoring.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/90_syn_monitoring.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    monitoring.syn.tools/infra: 'true'
+    name: syn-monitoring-openshift4-monitoring
+  name: syn-monitoring-openshift4-monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-main
+  name: alertmanager-main
+  namespace: syn-monitoring-openshift4-monitoring
+spec:
+  endpoints:
+    - interval: 30s
+      metricRelabelings:
+        - action: keep
+          regex: alertmanager_.*
+          sourceLabels:
+            - __name__
+      port: metrics
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        certFile: /etc/prometheus/secrets/ocp-metric-client-certs-monitoring/tls.crt
+        keyFile: /etc/prometheus/secrets/ocp-metric-client-certs-monitoring/tls.key
+        serverName: alertmanager-main.openshift-monitoring.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-monitoring
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: alert-router
+      app.kubernetes.io/instance: main
+      app.kubernetes.io/name: alertmanager
+      app.kubernetes.io/part-of: openshift-monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: prometheus-k8s
+  name: prometheus-k8s
+  namespace: syn-monitoring-openshift4-monitoring
+spec:
+  endpoints:
+    - interval: 30s
+      metricRelabelings:
+        - action: keep
+          regex: prometheus_.*
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: prometheus_(http|rule|target)_.*|prometheus_remote_storage_sent_batch_duration_seconds_bucket
+          sourceLabels:
+            - __name__
+      port: metrics
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        certFile: /etc/prometheus/secrets/ocp-metric-client-certs-monitoring/tls.crt
+        keyFile: /etc/prometheus/secrets/ocp-metric-client-certs-monitoring/tls.key
+        serverName: prometheus-k8s.openshift-monitoring.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-monitoring
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: k8s
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/part-of: openshift-monitoring

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
@@ -1,0 +1,162 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    syn_component: openshift4-monitoring
+  labels:
+    name: capacity
+  name: capacity
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: syn-CpuCapacity
+      rules:
+        - alert: SYN_ClusterCpuUsageHigh
+          annotations:
+            description: The cluster is close to using up all CPU resources. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} idle cpu cores accross cluster.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
+            syn_component: openshift4-monitoring
+          expr: sum by (label_appuio_io_node_class, label_kubernetes_io_os) (label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]),
+            "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}
+            * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os)
+            kube_node_labels) < 1.000000 * max by (label_appuio_io_node_class, label_kubernetes_io_os)
+            ((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"}
+            * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os)
+            kube_node_labels)
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-MemoryCapacity
+      rules:
+        - alert: SYN_ClusterLowOnMemory
+          annotations:
+            description: The cluster is close to using all of its memory. The cluster
+              might not be able to handle node failures or load spikes. Consider adding
+              new nodes.
+            message: Only {{ $value }} free memory on Worker Nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
+            syn_component: openshift4-monitoring
+          expr: sum by (label_appuio_io_node_class, label_kubernetes_io_os) (label_replace(node_memory_MemAvailable_bytes,
+            "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}
+            * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os)
+            kube_node_labels) < 1.000000 * max by (label_appuio_io_node_class, label_kubernetes_io_os)
+            ((kube_node_status_capacity{resource="memory"}) * on(node) group_left
+            kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class,
+            label_kubernetes_io_os) kube_node_labels)
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-PodCapacity
+      rules:
+        - alert: SYN_TooManyPods
+          annotations:
+            description: The cluster is close to the limit of running pods. The cluster
+              might not be able to handle node failures and might not be able to start
+              new pods. Consider adding new nodes.
+            message: Only {{ $value }} more pods can be started.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
+            syn_component: openshift4-monitoring
+          expr: sum by (label_appuio_io_node_class, label_kubernetes_io_os) (kube_node_status_capacity{resource="pods"}
+            * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class,
+            label_kubernetes_io_os) kube_node_labels) - sum by (label_appuio_io_node_class,
+            label_kubernetes_io_os) (kubelet_running_pods * on(node) group_left kube_node_role{role="app"}
+            * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os)
+            kube_node_labels) < 1.000000 * max by (label_appuio_io_node_class, label_kubernetes_io_os)
+            ((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"}
+            * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os)
+            kube_node_labels)
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-ResourceRequests
+      rules:
+        - alert: SYN_TooMuchCPURequested
+          annotations:
+            description: The cluster is close to assigning all CPU resources to running
+              pods. The cluster might not be able to handle node failures and might
+              soon not be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} cpu cores left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
+            syn_component: openshift4-monitoring
+          expr: sum by (label_appuio_io_node_class, label_kubernetes_io_os) (kube_node_status_allocatable{resource="cpu"}
+            * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class,
+            label_kubernetes_io_os) kube_node_labels) - sum by (label_appuio_io_node_class,
+            label_kubernetes_io_os) (kube_pod_resource_request{resource="cpu"} * on(node)
+            group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class,
+            label_kubernetes_io_os) kube_node_labels) < 1.000000 * max by (label_appuio_io_node_class,
+            label_kubernetes_io_os) ((kube_node_status_allocatable{resource="cpu"})
+            * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class,
+            label_kubernetes_io_os) kube_node_labels)
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_TooMuchMemoryRequested
+          annotations:
+            description: The cluster is close to assigning all memory to running pods.
+              The cluster might not be able to handle node failures and might not
+              be able to start new pods. Consider adding new nodes.
+            message: Only {{ $value }} memory left for new pods.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
+            syn_component: openshift4-monitoring
+          expr: sum by (label_appuio_io_node_class, label_kubernetes_io_os) (kube_node_status_allocatable{resource="memory"}
+            * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class,
+            label_kubernetes_io_os) kube_node_labels) - sum by (label_appuio_io_node_class,
+            label_kubernetes_io_os) (kube_pod_resource_request{resource="memory"}
+            * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class,
+            label_kubernetes_io_os) kube_node_labels) < 1.000000 * max by (label_appuio_io_node_class,
+            label_kubernetes_io_os) ((kube_node_status_allocatable{resource="memory"})
+            * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class,
+            label_kubernetes_io_os) kube_node_labels)
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-UnusedCapacity
+      rules:
+        - alert: SYN_ClusterHasUnusedNodes
+          annotations:
+            description: The cluster has {{ $value }} unused nodes. Consider removing
+              unused nodes.
+            message: Cluster has unused nodes.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
+            syn_component: openshift4-monitoring
+          expr: |-
+            min by (label_appuio_io_node_class, label_kubernetes_io_os) ((
+              label_replace(
+                (sum by (label_appuio_io_node_class, label_kubernetes_io_os) (kube_node_status_capacity{resource="pods"} * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os) kube_node_labels) - sum by (label_appuio_io_node_class, label_kubernetes_io_os) (kubelet_running_pods * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os) kube_node_labels)) / max by (label_appuio_io_node_class, label_kubernetes_io_os) ((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os) kube_node_labels)
+              , "resource", "pods", "", "")
+            ) or (
+              label_replace(
+                (sum by (label_appuio_io_node_class, label_kubernetes_io_os) (kube_node_status_allocatable{resource="memory"} * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os) kube_node_labels) - sum by (label_appuio_io_node_class, label_kubernetes_io_os) (kube_pod_resource_request{resource="memory"} * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os) kube_node_labels)) / max by (label_appuio_io_node_class, label_kubernetes_io_os) ((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os) kube_node_labels)
+              , "resource", "requested_memory", "", "")
+            ) or (
+              label_replace(
+                (sum by (label_appuio_io_node_class, label_kubernetes_io_os) (kube_node_status_allocatable{resource="cpu"} * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os) kube_node_labels) - sum by (label_appuio_io_node_class, label_kubernetes_io_os) (kube_pod_resource_request{resource="cpu"} * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os) kube_node_labels)) / max by (label_appuio_io_node_class, label_kubernetes_io_os) ((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os) kube_node_labels)
+              , "resource", "requested_cpu", "", "")
+            ) or (
+              label_replace(
+                sum by (label_appuio_io_node_class, label_kubernetes_io_os) (label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os) kube_node_labels) / max by (label_appuio_io_node_class, label_kubernetes_io_os) ((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os) kube_node_labels)
+              , "resource", "memory", "", "")
+            ) or (
+              label_replace(
+                sum by (label_appuio_io_node_class, label_kubernetes_io_os) (label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]), "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os) kube_node_labels) / max by (label_appuio_io_node_class, label_kubernetes_io_os) ((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"} * on(node) group_left(label_appuio_io_node_class, label_kubernetes_io_os) kube_node_labels)
+              , "resource", "cpu", "", "")
+            )
+            ) > 4.000000
+          for: 8h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1,0 +1,3152 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    role: alert-rules
+  name: syn-k8s-rules
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: syn-CloudCredentialOperator
+      rules:
+        - alert: SYN_CloudCredentialOperatorDeprovisioningFailed
+          annotations:
+            description: While processing a CredentialsRequest marked for deletion,
+              the Cloud Credential Operator encountered an issue. Check the conditions
+              of all CredentialsRequests with 'oc get credentialsrequest -A' to find
+              any CredentialsRequest(s) with a .status.condition showing a condition
+              type of CredentialsDeprovisionFailure set to True for more details on
+              the issue.
+            message: CredentialsRequest(s) unable to be cleaned up
+            summary: One or more CredentialsRequest CRs are unable to be deleted.
+            syn_component: openshift4-monitoring
+          expr: cco_credentials_requests_conditions{condition="CredentialsDeprovisionFailure"}
+            > 0
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_CloudCredentialOperatorInsufficientCloudCreds
+          annotations:
+            description: The Cloud Credential Operator has determined that there are
+              insufficient permissions to process one or more CredentialsRequest CRs.
+              Check the conditions of all CredentialsRequests with 'oc get credentialsrequest
+              -A' to find any CredentialsRequest(s) with a .status.condition showing
+              a condition type of InsufficientCloudCreds set to True for more details.
+            message: Cluster's cloud credentials insufficient for minting or passthrough
+            summary: Problem with the available platform credentials.
+            syn_component: openshift4-monitoring
+          expr: cco_credentials_requests_conditions{condition="InsufficientCloudCreds"}
+            > 0
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_CloudCredentialOperatorProvisioningFailed
+          annotations:
+            description: While processing a CredentialsRequest, the Cloud Credential
+              Operator encountered an issue. Check the conditions of all CredentialsRequets
+              with 'oc get credentialsrequest -A' to find any CredentialsRequest(s)
+              with a .stats.condition showing a condition type of CredentialsProvisionFailure
+              set to True for more details on the issue.
+            message: CredentialsRequest(s) unable to be fulfilled
+            summary: One or more CredentialsRequest CRs are unable to be processed.
+            syn_component: openshift4-monitoring
+          expr: cco_credentials_requests_conditions{condition="CredentialsProvisionFailure"}
+            > 0
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_CloudCredentialOperatorStaleCredentials
+          annotations:
+            description: The Cloud Credential Operator (CCO) has detected one or more
+              stale CredentialsRequest CRs that need to be manually deleted. When
+              the CCO is in Manual credentials mode, it will not automatially clean
+              up stale CredentialsRequest CRs (that may no longer be necessary in
+              the present version of OpenShift because it could involve needing to
+              clean up manually created cloud resources. Check the conditions of all
+              CredentialsRequests with 'oc get credentialsrequest -A' to find any
+              CredentialsRequest(s) with a .status.condition showing a condition type
+              of StaleCredentials set to True. Determine the appropriate steps to
+              clean up/deprovision any previously provisioned cloud resources. Finally,
+              delete the CredentialsRequest with an 'oc delete'.
+            message: 1 or more credentials requests are stale and should be deleted.
+              Check the status.conditions on CredentialsRequest CRs to identify the
+              stale one(s).
+            summary: One or more CredentialsRequest CRs are stale and should be deleted.
+            syn_component: openshift4-monitoring
+          expr: cco_credentials_requests_conditions{condition="StaleCredentials"}
+            > 0
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_CloudCredentialOperatorTargetNamespaceMissing
+          annotations:
+            description: At least one CredentialsRequest custom resource has specified
+              in its .spec.secretRef.namespace field a namespace which does not presently
+              exist. This means the Cloud Credential Operator in the openshift-cloud-credential-operator
+              namespace cannot process the CredentialsRequest resource. Check the
+              conditions of all CredentialsRequests with 'oc get credentialsrequest
+              -A' to find any CredentialsRequest(s) with a .status.condition showing
+              a condition type of MissingTargetNamespace set to True.
+            message: CredentialsRequest(s) pointing to non-existent namespace
+            summary: One ore more CredentialsRequest CRs are asking to save credentials
+              to a non-existent namespace.
+            syn_component: openshift4-monitoring
+          expr: cco_credentials_requests_conditions{condition="MissingTargetNamespace"}
+            > 0
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-ImageRegistryOperator
+      rules:
+        - alert: SYN_ImageRegistryStorageReconfigured
+          annotations:
+            message: |
+              Image Registry Storage configuration has changed in the last 30
+              minutes. This change may have caused data loss.
+            syn_component: openshift4-monitoring
+          expr: increase(image_registry_operator_storage_reconfigured_total[30m])
+            > 0
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-SamplesOperator
+      rules:
+        - alert: SYN_SamplesDegraded
+          annotations:
+            message: |
+              Samples could not be deployed and the operator is degraded. Review the "openshift-samples" ClusterOperator object for further details.
+            syn_component: openshift4-monitoring
+          expr: openshift_samples_degraded_info == 1
+          for: 2h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_SamplesImagestreamImportFailing
+          annotations:
+            message: |
+              Samples operator is detecting problems with imagestream image imports.  You can look at the "openshift-samples"
+              ClusterOperator object for details. Most likely there are issues with the external image registry hosting
+              the images that needs to be investigated.  Or you can consider marking samples operator Removed if you do not
+              care about having sample imagestreams available.  The list of ImageStreams for which samples operator is
+              retrying imports:
+              {{ range query "openshift_samples_retry_imagestream_import_total > 0" }}
+                 {{ .Labels.imagestreamname }}
+              {{ end }}
+            syn_component: openshift4-monitoring
+          expr: sum(openshift_samples_retry_imagestream_import_total) - sum(openshift_samples_retry_imagestream_import_total
+            offset 30m) > sum(openshift_samples_failed_imagestream_import_info)
+          for: 2h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_SamplesInvalidConfig
+          annotations:
+            message: |
+              Samples operator has been given an invalid configuration.
+            syn_component: openshift4-monitoring
+          expr: openshift_samples_invalidconfig_info == 1
+          for: 2h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_SamplesMissingSecret
+          annotations:
+            message: |
+              Samples operator cannot find the samples pull secret in the openshift namespace.
+            syn_component: openshift4-monitoring
+          expr: openshift_samples_invalidsecret_info{reason="missing_secret"} == 1
+          for: 2h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_SamplesMissingTBRCredential
+          annotations:
+            message: |
+              The samples operator cannot find credentials for 'registry.redhat.io'. Many of the sample ImageStreams will fail to import unless the 'samplesRegistry' in the operator configuration is changed.
+            syn_component: openshift4-monitoring
+          expr: openshift_samples_invalidsecret_info{reason="missing_tbr_credential"}
+            == 1
+          for: 2h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_SamplesRetriesMissingOnImagestreamImportFailing
+          annotations:
+            message: |
+              Samples operator is detecting problems with imagestream image imports, and the periodic retries of those
+              imports are not occurring.  Contact support.  You can look at the "openshift-samples" ClusterOperator object
+              for details. Most likely there are issues with the external image registry hosting the images that need to
+              be investigated.  The list of ImageStreams that have failing imports are:
+              {{ range query "openshift_samples_failed_imagestream_import_info > 0" }}
+                {{ .Labels.name }}
+              {{ end }}
+              However, the list of ImageStreams for which samples operator is retrying imports is:
+              retrying imports:
+              {{ range query "openshift_samples_retry_imagestream_import_total > 0" }}
+                 {{ .Labels.imagestreamname }}
+              {{ end }}
+            syn_component: openshift4-monitoring
+          expr: sum(openshift_samples_failed_imagestream_import_info) > sum(openshift_samples_retry_imagestream_import_total)
+            - sum(openshift_samples_retry_imagestream_import_total offset 30m)
+          for: 2h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_SamplesTBRInaccessibleOnBoot
+          annotations:
+            message: |-
+              One of two situations has occurred.  Either
+              samples operator could not access 'registry.redhat.io' during its initial installation and it bootstrapped as removed.
+              If this is expected, and stems from installing in a restricted network environment, please note that if you
+              plan on mirroring images associated with sample imagestreams into a registry available in your restricted
+              network environment, and subsequently moving samples operator back to 'Managed' state, a list of the images
+              associated with each image stream tag from the samples catalog is
+              provided in the 'imagestreamtag-to-image' config map in the 'openshift-cluster-samples-operator' namespace to
+              assist the mirroring process.
+              Or, the use of allowed registries or blocked registries with global imagestream configuration will not allow
+              samples operator to create imagestreams using the default image registry 'registry.redhat.io'.
+            syn_component: openshift4-monitoring
+          expr: openshift_samples_tbr_inaccessible_info == 1
+          for: 2d
+          labels:
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-alertmanager.rules
+      rules:
+        - alert: SYN_AlertmanagerClusterDown
+          annotations:
+            description: '{{ $value | humanizePercentage }} of Alertmanager instances
+              within the {{$labels.job}} cluster have been up for less than half of
+              the last 5m.'
+            summary: Half or more of the Alertmanager instances within the same cluster
+              are down.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              count by (namespace,service) (
+                avg_over_time(up{job="alertmanager-main",namespace="openshift-monitoring"}[5m]) < 0.5
+              )
+            /
+              count by (namespace,service) (
+                up{job="alertmanager-main",namespace="openshift-monitoring"}
+              )
+            )
+            >= 0.5
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_AlertmanagerClusterFailedToSendAlerts
+          annotations:
+            description: The minimum notification failure rate to {{ $labels.integration
+              }} sent from any instance in the {{$labels.job}} cluster is {{ $value
+              | humanizePercentage }}.
+            summary: All Alertmanager instances in a cluster failed to send notifications
+              to a critical integration.
+            syn_component: openshift4-monitoring
+          expr: |
+            min by (namespace,service, integration) (
+              rate(alertmanager_notifications_failed_total{job="alertmanager-main",namespace="openshift-monitoring", integration=~`.*`}[5m])
+            /
+              rate(alertmanager_notifications_total{job="alertmanager-main",namespace="openshift-monitoring", integration=~`.*`}[5m])
+            )
+            > 0.01
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_AlertmanagerConfigInconsistent
+          annotations:
+            description: Alertmanager instances within the {{$labels.job}} cluster
+              have different configurations.
+            summary: Alertmanager instances within the same cluster have different
+              configurations.
+            syn_component: openshift4-monitoring
+          expr: |
+            count by (namespace,service) (
+              count_values by (namespace,service) ("config_hash", alertmanager_config_hash{job="alertmanager-main",namespace="openshift-monitoring"})
+            )
+            != 1
+          for: 20m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_AlertmanagerFailedReload
+          annotations:
+            description: Configuration has failed to load for {{ $labels.namespace
+              }}/{{ $labels.pod}}.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/AlertmanagerFailedReload.md
+            summary: Reloading an Alertmanager configuration has failed.
+            syn_component: openshift4-monitoring
+          expr: |
+            # Without max_over_time, failed scrapes could create false negatives, see
+            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+            max_over_time(alertmanager_config_last_reload_successful{job="alertmanager-main",namespace="openshift-monitoring"}[5m]) == 0
+          for: 10m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_AlertmanagerFailedToSendAlerts
+          annotations:
+            description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
+              to send {{ $value | humanizePercentage }} of notifications to {{ $labels.integration
+              }}.
+            summary: An Alertmanager instance failed to send notifications.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              rate(alertmanager_notifications_failed_total{job="alertmanager-main",namespace="openshift-monitoring"}[5m])
+            /
+              rate(alertmanager_notifications_total{job="alertmanager-main",namespace="openshift-monitoring"}[5m])
+            )
+            > 0.01
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_AlertmanagerMembersInconsistent
+          annotations:
+            description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
+              only found {{ $value }} members of the {{$labels.job}} cluster.
+            summary: A member of an Alertmanager cluster has not found all other cluster
+              members.
+            syn_component: openshift4-monitoring
+          expr: |
+            # Without max_over_time, failed scrapes could create false negatives, see
+            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+              max_over_time(alertmanager_cluster_members{job="alertmanager-main",namespace="openshift-monitoring"}[5m])
+            < on (namespace,service) group_left
+              count by (namespace,service) (max_over_time(alertmanager_cluster_members{job="alertmanager-main",namespace="openshift-monitoring"}[5m]))
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-apiserver-requests-in-flight
+      rules: []
+    - name: syn-cluster-machine-approver.rules
+      rules:
+        - alert: SYN_MachineApproverMaxPendingCSRsReached
+          annotations:
+            description: |
+              The number of pending CertificateSigningRequests has exceeded the
+              maximum threshold (current number of machine + 100). Check the
+              pending CSRs to determine which machines need approval, also check
+              that the nodelink controller is running in the openshift-machine-api
+              namespace.
+            summary: max pending CSRs threshold reached.
+            syn_component: openshift4-monitoring
+          expr: |
+            mapi_current_pending_csr > mapi_max_pending_csr
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-cluster-network-operator-sdn.rules
+      rules:
+        - alert: SYN_ClusterProxyApplySlow
+          annotations:
+            summary: The cluster is taking too long, on average, to apply kubernetes
+              service rules to iptables.
+            syn_component: openshift4-monitoring
+          expr: |
+            histogram_quantile(0.95, sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket[5m])) by (le)) > 10
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeProxyApplySlow
+          annotations:
+            summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node
+              {{"}}"}} is taking too long, on average, to apply kubernetes service
+              rules to iptables.
+            syn_component: openshift4-monitoring
+          expr: |
+            histogram_quantile(.95, kubeproxy_sync_proxy_rules_duration_seconds_bucket)
+            * on(namespace, pod) group_right topk by (namespace, pod) (1, kube_pod_info{namespace="openshift-sdn",  pod=~"sdn-[^-]*"}) > 15
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeProxyApplyStale
+          annotations:
+            summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node
+              {{"}}"}} has stale kubernetes service rules in iptables.
+            syn_component: openshift4-monitoring
+          expr: |
+            (kubeproxy_sync_proxy_rules_last_queued_timestamp_seconds - kubeproxy_sync_proxy_rules_last_timestamp_seconds)
+            * on(namespace, pod) group_right() topk by (namespace, pod) (1, kube_pod_info{namespace="openshift-sdn",pod=~"sdn-[^-]*"})
+            > 30
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeWithoutSDNController
+          annotations:
+            summary: All control plane nodes should be running a sdn controller pod,
+              {{"{{"}} $labels.node {{"}}"}} is not.
+            syn_component: openshift4-monitoring
+          expr: |
+            count(kube_node_role{role="master"} == 1) != count(kube_pod_info{namespace="openshift-sdn",  pod=~"sdn-controller.*"})
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeWithoutSDNPod
+          annotations:
+            summary: All nodes should be running an sdn pod, {{"{{"}} $labels.node
+              {{"}}"}} is not.
+            syn_component: openshift4-monitoring
+          expr: |
+            (kube_node_info unless on(node) topk by (node) (1, kube_pod_info{namespace="openshift-sdn",  pod=~"sdn-[^-]*"})) > 0
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_SDNPodNotReady
+          annotations:
+            summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node
+              {{"}}"}} is not ready.
+            syn_component: openshift4-monitoring
+          expr: |
+            kube_pod_status_ready{namespace='openshift-sdn', condition='true'} == 0
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-cluster-operators
+      rules:
+        - alert: SYN_ClusterNotUpgradeable
+          annotations:
+            description: In most cases, you will still be able to apply patch releases.
+              Reason {{ with $cluster_operator_conditions := "cluster_operator_conditions"
+              | query}}{{range $value := .}}{{if and (eq (label "name" $value) "version")
+              (eq (label "condition" $value) "Upgradeable") (eq (label "endpoint"
+              $value) "metrics") (eq (value $value) 0.0) (ne (len (label "reason"
+              $value)) 0) }}{{label "reason" $value}}.{{end}}{{end}}{{end}} For more
+              information refer to 'oc adm upgrade'{{ with $console_url := "console_url"
+              | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} or
+              {{ label "url" (first $console_url ) }}/settings/cluster/{{ end }}{{
+              end }}.
+            summary: One or more cluster operators have been blocking minor version
+              cluster upgrades for at least an hour.
+            syn_component: openshift4-monitoring
+          expr: |
+            max by (name, condition, endpoint) (cluster_operator_conditions{name="version", condition="Upgradeable", endpoint="metrics"} == 0)
+          for: 60m
+          labels:
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ClusterOperatorDegraded
+          annotations:
+            description: The {{ $labels.name }} operator is degraded because {{ $labels.reason
+              }}, and the components it manages may have reduced quality of service.  Cluster
+              upgrades may not complete. For more information refer to 'oc get -o
+              yaml clusteroperator {{ $labels.name }}'{{ with $console_url := "console_url"
+              | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} or
+              {{ label "url" (first $console_url ) }}/settings/cluster/{{ end }}{{
+              end }}.
+            summary: Cluster operator has been degraded for 30 minutes.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              cluster_operator_conditions{job="cluster-version-operator", condition="Degraded"}
+              or on (name)
+              group by (name) (cluster_operator_up{job="cluster-version-operator"})
+            ) == 1
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ClusterOperatorDown
+          annotations:
+            description: The {{ $labels.name }} operator may be down or disabled,
+              and the components it manages may be unavailable or degraded.  Cluster
+              upgrades may not complete. For more information refer to 'oc get -o
+              yaml clusteroperator {{ $labels.name }}'{{ with $console_url := "console_url"
+              | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} or
+              {{ label "url" (first $console_url ) }}/settings/cluster/{{ end }}{{
+              end }}.
+            summary: Cluster operator has not been available for 10 minutes.
+            syn_component: openshift4-monitoring
+          expr: |
+            cluster_operator_up{job="cluster-version-operator"} == 0
+          for: 10m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ClusterOperatorFlapping
+          annotations:
+            description: The  {{ $labels.name }} operator behavior might cause upgrades
+              to be unstable. For more information refer to 'oc get -o yaml clusteroperator
+              {{ $labels.name }}'{{ with $console_url := "console_url" | query }}{{
+              if ne (len (label "url" (first $console_url ) ) ) 0}} or {{ label "url"
+              (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}.
+            summary: Cluster operator up status is changing often.
+            syn_component: openshift4-monitoring
+          expr: |
+            changes(cluster_operator_up{job="cluster-version-operator"}[2m]) > 2
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-cluster-version
+      rules:
+        - alert: SYN_CannotRetrieveUpdates
+          annotations:
+            description: Failure to retrieve updates means that cluster administrators
+              will need to monitor for available updates on their own or risk falling
+              behind on security or other bugfixes. If the failure is expected, you
+              can clear spec.channel in the ClusterVersion object to tell the cluster-version
+              operator to not retrieve updates. Failure reason {{ with $cluster_operator_conditions
+              := "cluster_operator_conditions" | query}}{{range $value := .}}{{if
+              and (eq (label "name" $value) "version") (eq (label "condition" $value)
+              "RetrievedUpdates") (eq (label "endpoint" $value) "metrics") (eq (value
+              $value) 0.0)}}{{label "reason" $value}} {{end}}{{end}}{{end}}. {{ with
+              $console_url := "console_url" | query }}{{ if ne (len (label "url" (first
+              $console_url ) ) ) 0}} For more information refer to {{ label "url"
+              (first $console_url ) }}/settings/cluster/.{{ end }}{{ end }}
+            summary: Cluster version operator has not retrieved updates in {{ $value
+              | humanizeDuration }}.
+            syn_component: openshift4-monitoring
+          expr: |
+            (time()-cluster_version_operator_update_retrieval_timestamp_seconds) >= 3600 and ignoring(condition, name, reason) cluster_operator_conditions{name="version", condition="RetrievedUpdates", endpoint="metrics", reason!="NoChannel"}
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ClusterVersionOperatorDown
+          annotations:
+            description: The operator may be down or disabled. The cluster will not
+              be kept up to date and upgrades will not be possible. Inspect the openshift-cluster-version
+              namespace for events or changes to the cluster-version-operator deployment
+              or pods to diagnose and repair. {{ with $console_url := "console_url"
+              | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} For
+              more information refer to {{ label "url" (first $console_url ) }}/k8s/cluster/projects/openshift-cluster-version.{{
+              end }}{{ end }}
+            summary: Cluster version operator has disappeared from Prometheus target
+              discovery.
+            syn_component: openshift4-monitoring
+          expr: |
+            absent(up{job="cluster-version-operator"} == 1)
+          for: 10m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeControllerManagerDown
+          annotations:
+            description: KubeControllerManager has disappeared from Prometheus target
+              discovery.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/KubeControllerManagerDown.md
+            summary: Target disappeared from Prometheus target discovery.
+            syn_component: openshift4-monitoring
+          expr: |
+            absent(up{job="kube-controller-manager"} == 1)
+          for: 15m
+          labels:
+            namespace: openshift-kube-controller-manager
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeSchedulerDown
+          annotations:
+            description: KubeScheduler has disappeared from Prometheus target discovery.
+            summary: Target disappeared from Prometheus target discovery.
+            syn_component: openshift4-monitoring
+          expr: |
+            absent(up{job="scheduler"} == 1)
+          for: 15m
+          labels:
+            namespace: openshift-kube-scheduler
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PodDisruptionBudgetAtLimit
+          annotations:
+            description: The pod disruption budget is at the minimum disruptions allowed
+              level. The number of current healthy pods is equal to the desired healthy
+              pods.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetAtLimit.md
+            summary: The pod disruption budget is preventing further disruption to
+              pods.
+            syn_component: openshift4-monitoring
+          expr: |
+            max by(namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy == kube_poddisruptionbudget_status_desired_healthy and on (namespace, poddisruptionbudget) kube_poddisruptionbudget_status_expected_pods > 0)
+          for: 60m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PodDisruptionBudgetLimit
+          annotations:
+            description: The pod disruption budget is below the minimum disruptions
+              allowed level and is not satisfied. The number of current healthy pods
+              is less than the desired healthy pods.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetLimit.md
+            summary: The pod disruption budget registers insufficient amount of pods.
+            syn_component: openshift4-monitoring
+          expr: |
+            max by (namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy < kube_poddisruptionbudget_status_desired_healthy)
+          for: 15m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_TechPreviewNoUpgrade
+          annotations:
+            description: Cluster has enabled Technology Preview features that cannot
+              be undone and will prevent upgrades. The TechPreviewNoUpgrade feature
+              set is not recommended on production clusters.
+            summary: Cluster has enabled tech preview features that will prevent upgrades.
+            syn_component: openshift4-monitoring
+          expr: |
+            cluster_feature_set{name!="", namespace="openshift-kube-apiserver-operator"} == 0
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_UpdateAvailable
+          annotations:
+            description: For more information refer to 'oc adm upgrade'{{ with $console_url
+              := "console_url" | query }}{{ if ne (len (label "url" (first $console_url
+              ) ) ) 0}} or {{ label "url" (first $console_url ) }}/settings/cluster/{{
+              end }}{{ end }}.
+            summary: Your upstream update recommendation service recommends you update
+              your cluster.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum by (channel,upstream) (cluster_version_available_updates) > 0
+          labels:
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-config-reloaders
+      rules:
+        - alert: SYN_ConfigReloaderSidecarErrors
+          annotations:
+            description: |-
+              Errors encountered while the {{$labels.pod}} config-reloader sidecar attempts to sync config in {{$labels.namespace}} namespace.
+              As a result, configuration for service running in {{$labels.pod}} may be stale and cannot be updated anymore.
+            summary: config-reloader sidecar has not had a successful reload for 10m
+            syn_component: openshift4-monitoring
+          expr: |
+            max_over_time(reloader_last_reload_successful{namespace=~".+"}[5m]) == 0
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-control-plane-cpu-utilization
+      rules:
+        - alert: SYN_ExtremelyHighIndividualControlPlaneCPU
+          annotations:
+            description: Extreme CPU pressure can cause slow serialization and poor
+              performance from the kube-apiserver and etcd. When this happens, there
+              is a risk of clients seeing non-responsive API requests which are issued
+              again causing even more CPU pressure. It can also cause failing liveness
+              probes due to slow etcd responsiveness on the backend. If one kube-apiserver
+              fails under this condition, chances are you will experience a cascade
+              as the remaining kube-apiservers are also under-provisioned. To fix
+              this, increase the CPU and memory on your control plane nodes.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-apiserver-operator/ExtremelyHighIndividualControlPlaneCPU.md
+            summary: CPU utilization on a single control plane node is very high,
+              more CPU pressure is likely to cause a failover; increase available
+              CPU.
+            syn_component: openshift4-monitoring
+          expr: |
+            100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[1m])) * 100) > 90 AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
+          for: 5m
+          labels:
+            namespace: openshift-kube-apiserver
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ExtremelyHighIndividualControlPlaneCPU
+          annotations:
+            description: Extreme CPU pressure can cause slow serialization and poor
+              performance from the kube-apiserver and etcd. When this happens, there
+              is a risk of clients seeing non-responsive API requests which are issued
+              again causing even more CPU pressure. It can also cause failing liveness
+              probes due to slow etcd responsiveness on the backend. If one kube-apiserver
+              fails under this condition, chances are you will experience a cascade
+              as the remaining kube-apiservers are also under-provisioned. To fix
+              this, increase the CPU and memory on your control plane nodes.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-apiserver-operator/ExtremelyHighIndividualControlPlaneCPU.md
+            summary: Sustained high CPU utilization on a single control plane node,
+              more CPU pressure is likely to cause a failover; increase available
+              CPU.
+            syn_component: openshift4-monitoring
+          expr: |
+            100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[1m])) * 100) > 90 AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
+          for: 1h
+          labels:
+            namespace: openshift-kube-apiserver
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_HighOverallControlPlaneCPU
+          annotations:
+            description: Given three control plane nodes, the overall CPU utilization
+              may only be about 2/3 of all available capacity. This is because if
+              a single control plane node fails, the remaining two must handle the
+              load of the cluster in order to be HA. If the cluster is using more
+              than 2/3 of all capacity, if one control plane node fails, the remaining
+              two are likely to fail when they take the load. To fix this, increase
+              the CPU and memory on your control plane nodes.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-apiserver-operator/ExtremelyHighIndividualControlPlaneCPU.md
+            summary: CPU utilization across all three control plane nodes is higher
+              than two control plane nodes can sustain; a single control plane node
+              outage may cause a cascading failure; increase available CPU.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum(
+              100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[1m])) * 100)
+              AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
+            )
+            /
+            count(kube_node_role{role="master"})
+            > 60
+          for: 10m
+          labels:
+            namespace: openshift-kube-apiserver
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-etcd
+      rules:
+        - alert: SYN_etcdDatabaseHighFragmentationRatio
+          annotations:
+            description: 'etcd cluster "{{ $labels.job }}": database size in use on
+              instance {{ $labels.instance }} is {{ $value | humanizePercentage }}
+              of the actual allocated disk space, please run defragmentation (e.g.
+              etcdctl defrag) to retrieve the unused fragmented disk space.'
+            runbook_url: https://etcd.io/docs/v3.5/op-guide/maintenance/#defragmentation
+            summary: etcd database size in use is less than 50% of the actual allocated
+              storage.
+            syn_component: openshift4-monitoring
+          expr: |
+            (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5 and etcd_mvcc_db_total_size_in_use_in_bytes > 104857600
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_etcdDatabaseQuotaLowSpace
+          annotations:
+            description: 'etcd cluster "{{ $labels.job }}": database size exceeds
+              the defined quota on etcd instance {{ $labels.instance }}, please defrag
+              or increase the quota as the writes to etcd will be disabled when it
+              is full.'
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdDatabaseQuotaLowSpace.md
+            summary: etcd cluster database is running full.
+            syn_component: openshift4-monitoring
+          expr: |
+            (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+          for: 10m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_etcdExcessiveDatabaseGrowth
+          annotations:
+            description: 'etcd cluster "{{ $labels.job }}": Predicting running out
+              of disk space in the next four hours, based on write observations within
+              the past four hours on etcd instance {{ $labels.instance }}, please
+              check as it might be disruptive.'
+            summary: etcd cluster database growing very fast.
+            syn_component: openshift4-monitoring
+          expr: |
+            predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_etcdHighCommitDurations
+          annotations:
+            description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit
+              durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+            summary: etcd cluster 99th percentile commit durations are too high.
+            syn_component: openshift4-monitoring
+          expr: |
+            histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~".*etcd.*"}[5m]))
+            > 0.25
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_etcdHighFsyncDurations
+          annotations:
+            description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
+              durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+            summary: etcd cluster 99th percentile fsync durations are too high.
+            syn_component: openshift4-monitoring
+          expr: |
+            histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~".*etcd.*"}[5m]))
+            > 0.5
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_etcdHighFsyncDurations
+          annotations:
+            description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync
+              durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdHighFsyncDurations.md
+            summary: etcd cluster 99th percentile fsync durations are too high.
+            syn_component: openshift4-monitoring
+          expr: |
+            histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~".*etcd.*"}[5m]))
+            > 1
+          for: 10m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_etcdHighNumberOfFailedProposals
+          annotations:
+            description: 'etcd cluster "{{ $labels.job }}": {{ $value }} proposal
+              failures within the last 30 minutes on etcd instance {{ $labels.instance
+              }}.'
+            summary: etcd cluster has high number of proposal failures.
+            syn_component: openshift4-monitoring
+          expr: |
+            rate(etcd_server_proposals_failed_total{job=~".*etcd.*"}[15m]) > 5
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_etcdMemberCommunicationSlow
+          annotations:
+            description: 'etcd cluster "{{ $labels.job }}": member communication with
+              {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance
+              }}.'
+            summary: etcd cluster member communication is slow.
+            syn_component: openshift4-monitoring
+          expr: |
+            histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job=~".*etcd.*"}[5m]))
+            > 0.15
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_etcdMembersDown
+          annotations:
+            description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value
+              }}).'
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdMembersDown.md
+            summary: etcd cluster members are down.
+            syn_component: openshift4-monitoring
+          expr: |
+            max without (endpoint) (
+              sum without (instance) (up{job=~".*etcd.*"} == bool 0)
+            or
+              count without (To) (
+                sum without (instance) (rate(etcd_network_peer_sent_failures_total{job=~".*etcd.*"}[120s])) > 0.01
+              )
+            )
+            > 0
+          for: 10m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_etcdNoLeader
+          annotations:
+            description: 'etcd cluster "{{ $labels.job }}": member {{ $labels.instance
+              }} has no leader.'
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdNoLeader.md
+            summary: etcd cluster has no leader.
+            syn_component: openshift4-monitoring
+          expr: |
+            etcd_server_has_leader{job=~".*etcd.*"} == 0
+          for: 1m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-general.rules
+      rules:
+        - alert: Watchdog
+          annotations:
+            description: |
+              This is an alert meant to ensure that the entire alerting pipeline is functional.
+              This alert is always firing, therefore it should always be firing in Alertmanager
+              and always fire against a receiver. There are integrations with various notification
+              mechanisms that send a notification when this alert is not firing. For example the
+              "DeadMansSnitch" integration in PagerDuty.
+            summary: An alert that should always be firing to certify that Alertmanager
+              is working properly.
+            syn_component: openshift4-monitoring
+          expr: vector(1)
+          labels:
+            namespace: openshift-monitoring
+            severity: none
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-k8s.rules
+      rules: []
+    - name: syn-kube-apiserver-slos-basic
+      rules:
+        - alert: SYN_KubeAPIErrorBudgetBurn
+          annotations:
+            description: The API server is burning too much error budget. This alert
+              fires when too many requests are failing with high latency. Use the
+              'API Performance' monitoring dashboards to narrow down the request states
+              and latency. The 'etcd' monitoring dashboards also provides metrics
+              to help determine etcd stability and performance.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-apiserver-operator/KubeAPIErrorBudgetBurn.md
+            summary: The API server is burning too much error budget.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum(apiserver_request:burnrate1h) > (14.40 * 0.01000)
+            and
+            sum(apiserver_request:burnrate5m) > (14.40 * 0.01000)
+          for: 2m
+          labels:
+            long: 1h
+            namespace: openshift-kube-apiserver
+            severity: critical
+            short: 5m
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeAPIErrorBudgetBurn
+          annotations:
+            description: The API server is burning too much error budget. This alert
+              fires when too many requests are failing with high latency. Use the
+              'API Performance' monitoring dashboards to narrow down the request states
+              and latency. The 'etcd' monitoring dashboards also provides metrics
+              to help determine etcd stability and performance.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-apiserver-operator/KubeAPIErrorBudgetBurn.md
+            summary: The API server is burning too much error budget.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum(apiserver_request:burnrate6h) > (6.00 * 0.01000)
+            and
+            sum(apiserver_request:burnrate30m) > (6.00 * 0.01000)
+          for: 15m
+          labels:
+            long: 6h
+            namespace: openshift-kube-apiserver
+            severity: critical
+            short: 30m
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-kube-apiserver.rules
+      rules: []
+    - name: syn-kube-prometheus-general.rules
+      rules: []
+    - name: syn-kube-prometheus-node-recording.rules
+      rules: []
+    - name: syn-kube-scheduler.rules
+      rules: []
+    - name: syn-kube-state-metrics
+      rules:
+        - alert: SYN_KubeStateMetricsListErrors
+          annotations:
+            description: kube-state-metrics is experiencing errors at an elevated
+              rate in list operations. This is likely causing it to not be able to
+              expose metrics about Kubernetes objects correctly or at all.
+            summary: kube-state-metrics is experiencing errors in list operations.
+            syn_component: openshift4-monitoring
+          expr: |
+            (sum(rate(kube_state_metrics_list_total{job="kube-state-metrics",result="error"}[5m]))
+              /
+            sum(rate(kube_state_metrics_list_total{job="kube-state-metrics"}[5m])))
+            > 0.01
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeStateMetricsWatchErrors
+          annotations:
+            description: kube-state-metrics is experiencing errors at an elevated
+              rate in watch operations. This is likely causing it to not be able to
+              expose metrics about Kubernetes objects correctly or at all.
+            summary: kube-state-metrics is experiencing errors in watch operations.
+            syn_component: openshift4-monitoring
+          expr: |
+            (sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics",result="error"}[5m]))
+              /
+            sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics"}[5m])))
+            > 0.01
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-kubelet.rules
+      rules: []
+    - name: syn-kubernetes-apps
+      rules:
+        - alert: SYN_KubeContainerWaiting
+          annotations:
+            description: pod/{{ $labels.pod }} in namespace {{ $labels.namespace }}
+              on container {{ $labels.container}} has been in waiting state for longer
+              than 1 hour.
+            summary: Pod container waiting longer than 1 hour
+            syn_component: openshift4-monitoring
+          expr: |
+            sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}) > 0
+          for: 1h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeDaemonSetMisScheduled
+          annotations:
+            description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
+              $labels.daemonset }} are running where they are not supposed to run.'
+            summary: DaemonSet pods are misscheduled.
+            syn_component: openshift4-monitoring
+          expr: |
+            kube_daemonset_status_number_misscheduled{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"} > 0
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeDaemonSetNotScheduled
+          annotations:
+            description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
+              $labels.daemonset }} are not scheduled.'
+            summary: DaemonSet pods are not scheduled.
+            syn_component: openshift4-monitoring
+          expr: |
+            kube_daemonset_status_desired_number_scheduled{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+              -
+            kube_daemonset_status_current_number_scheduled{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"} > 0
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeDaemonSetRolloutStuck
+          annotations:
+            description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
+              has not finished or progressed for at least 30 minutes.
+            summary: DaemonSet rollout is stuck.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              (
+                kube_daemonset_status_current_number_scheduled{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+                 !=
+                kube_daemonset_status_desired_number_scheduled{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+              ) or (
+                kube_daemonset_status_number_misscheduled{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+                 !=
+                0
+              ) or (
+                kube_daemonset_status_updated_number_scheduled{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+                 !=
+                kube_daemonset_status_desired_number_scheduled{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+              ) or (
+                kube_daemonset_status_number_available{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+                 !=
+                kube_daemonset_status_desired_number_scheduled{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+              )
+            ) and (
+              changes(kube_daemonset_status_updated_number_scheduled{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}[5m])
+                ==
+              0
+            )
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeDeploymentGenerationMismatch
+          annotations:
+            description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
+              }} does not match, this indicates that the Deployment has failed but
+              has not been rolled back.
+            summary: Deployment generation mismatch due to possible roll-back
+            syn_component: openshift4-monitoring
+          expr: |
+            kube_deployment_status_observed_generation{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+              !=
+            kube_deployment_metadata_generation{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeHpaMaxedOut
+          annotations:
+            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
+              has been running at max replicas for longer than 15 minutes.
+            summary: HPA is running at max replicas
+            syn_component: openshift4-monitoring
+          expr: |
+            kube_horizontalpodautoscaler_status_current_replicas{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+              ==
+            kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeHpaReplicasMismatch
+          annotations:
+            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
+              has not matched the desired number of replicas for longer than 15 minutes.
+            summary: HPA has not matched descired number of replicas.
+            syn_component: openshift4-monitoring
+          expr: |
+            (kube_horizontalpodautoscaler_status_desired_replicas{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+              !=
+            kube_horizontalpodautoscaler_status_current_replicas{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"})
+              and
+            (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+              >
+            kube_horizontalpodautoscaler_spec_min_replicas{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"})
+              and
+            (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+              <
+            kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"})
+              and
+            changes(kube_horizontalpodautoscaler_status_current_replicas{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}[15m]) == 0
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeJobCompletion
+          annotations:
+            description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
+              more than 12 hours to complete.
+            summary: Job did not complete in time
+            syn_component: openshift4-monitoring
+          expr: |
+            kube_job_spec_completions{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"} - kube_job_status_succeeded{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}  > 0
+          for: 12h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeJobFailed
+          annotations:
+            description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
+              to complete. Removing failed job after investigation should clear this
+              alert.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeJobFailed.md
+            summary: Job failed to complete.
+            syn_component: openshift4-monitoring
+          expr: |
+            kube_job_failed{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}  > 0
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubePodCrashLooping
+          annotations:
+            description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
+              }}) is in waiting state (reason: "CrashLoopBackOff").'
+            summary: Pod is crash looping.
+            syn_component: openshift4-monitoring
+          expr: |
+            max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}[5m]) >= 1
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubePodNotReady
+          annotations:
+            description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
+              a non-ready state for longer than 15 minutes.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePodNotReady.md
+            summary: Pod has been in a non-ready state for more than 15 minutes.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum by (namespace, pod) (
+              max by(namespace, pod) (
+                kube_pod_status_phase{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", phase=~"Pending|Unknown"}
+              ) * on(namespace, pod) group_left(owner_kind) topk by(namespace, pod) (
+                1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
+              )
+            ) > 0
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeStatefulSetGenerationMismatch
+          annotations:
+            description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
+              }} does not match, this indicates that the StatefulSet has failed but
+              has not been rolled back.
+            summary: StatefulSet generation mismatch due to possible roll-back
+            syn_component: openshift4-monitoring
+          expr: |
+            kube_statefulset_status_observed_generation{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+              !=
+            kube_statefulset_metadata_generation{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeStatefulSetReplicasMismatch
+          annotations:
+            description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
+              }} has not matched the expected number of replicas for longer than 15
+              minutes.
+            summary: Deployment has not matched the expected number of replicas.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              kube_statefulset_status_replicas_ready{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+                !=
+              kube_statefulset_status_replicas{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+            ) and (
+              changes(kube_statefulset_status_replicas_updated{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}[10m])
+                ==
+              0
+            )
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeStatefulSetUpdateNotRolledOut
+          annotations:
+            description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
+              }} update has not been rolled out.
+            summary: StatefulSet update has not been rolled out.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              max without (revision) (
+                kube_statefulset_status_current_revision{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+                  unless
+                kube_statefulset_status_update_revision{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+              )
+                *
+              (
+                kube_statefulset_replicas{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+                  !=
+                kube_statefulset_status_replicas_updated{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+              )
+            )  and (
+              changes(kube_statefulset_status_replicas_updated{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}[5m])
+                ==
+              0
+            )
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-kubernetes-recurring.rules
+      rules: []
+    - name: syn-kubernetes-resources
+      rules:
+        - alert: SYN_KubeCPUOvercommit
+          annotations:
+            description: Cluster has overcommitted CPU resource requests for Pods
+              by {{ $value }} CPU shares and cannot tolerate node failure.
+            summary: Cluster has overcommitted CPU resource requests.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum(namespace_cpu:kube_pod_container_resource_requests:sum{}) - (sum(kube_node_status_allocatable{resource="cpu"}) - max(kube_node_status_allocatable{resource="cpu"})) > 0
+            and
+            (sum(kube_node_status_allocatable{resource="cpu"}) - max(kube_node_status_allocatable{resource="cpu"})) > 0
+          for: 10m
+          labels:
+            namespace: kube-system
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeCPUQuotaOvercommit
+          annotations:
+            description: Cluster has overcommitted CPU resource requests for Namespaces.
+            summary: Cluster has overcommitted CPU resource requests.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum(min without(resource) (kube_resourcequota{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
+              /
+            sum(kube_node_status_allocatable{resource="cpu", job="kube-state-metrics"})
+              > 1.5
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeMemoryOvercommit
+          annotations:
+            description: Cluster has overcommitted memory resource requests for Pods
+              by {{ $value | humanize }} bytes and cannot tolerate node failure.
+            summary: Cluster has overcommitted memory resource requests.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum(namespace_memory:kube_pod_container_resource_requests:sum{}) - (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"})) > 0
+            and
+            (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"})) > 0
+          for: 10m
+          labels:
+            namespace: kube-system
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeMemoryQuotaOvercommit
+          annotations:
+            description: Cluster has overcommitted memory resource requests for Namespaces.
+            summary: Cluster has overcommitted memory resource requests.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum(min without(resource) (kube_resourcequota{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
+              /
+            sum(kube_node_status_allocatable{resource="memory", job="kube-state-metrics"})
+              > 1.5
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeQuotaAlmostFull
+          annotations:
+            description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
+              }} of its {{ $labels.resource }} quota.
+            summary: Namespace quota is going to be full.
+            syn_component: openshift4-monitoring
+          expr: |
+            kube_resourcequota{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", type="used"}
+              / ignoring(instance, job, type)
+            (kube_resourcequota{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", type="hard"} > 0)
+              > 0.9 < 1
+          for: 15m
+          labels:
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeQuotaExceeded
+          annotations:
+            description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
+              }} of its {{ $labels.resource }} quota.
+            summary: Namespace quota has exceeded the limits.
+            syn_component: openshift4-monitoring
+          expr: |
+            kube_resourcequota{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", type="used"}
+              / ignoring(instance, job, type)
+            (kube_resourcequota{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", type="hard"} > 0)
+              > 1
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeQuotaFullyUsed
+          annotations:
+            description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
+              }} of its {{ $labels.resource }} quota.
+            summary: Namespace quota is fully used.
+            syn_component: openshift4-monitoring
+          expr: |
+            kube_resourcequota{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", type="used"}
+              / ignoring(instance, job, type)
+            (kube_resourcequota{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", type="hard"} > 0)
+              == 1
+          for: 15m
+          labels:
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-kubernetes-storage
+      rules:
+        - alert: SYN_KubePersistentVolumeErrors
+          annotations:
+            description: The persistent volume {{ $labels.persistentvolume }} has
+              status {{ $labels.phase }}.
+            summary: PersistentVolume is having issues with provisioning.
+            syn_component: openshift4-monitoring
+          expr: |
+            kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"} > 0
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubePersistentVolumeFillingUp
+          annotations:
+            description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
+              }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage
+              }} free.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePersistentVolumeFillingUp.md
+            summary: PersistentVolume is filling up.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              kubelet_volume_stats_available_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
+                /
+              kubelet_volume_stats_capacity_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
+            ) < 0.03
+            and
+            kubelet_volume_stats_used_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"} > 0
+            unless on(namespace, persistentvolumeclaim)
+            kube_persistentvolumeclaim_access_mode{namespace=~"(openshift-.*|kube-.*|default)", access_mode="ReadOnlyMany"} == 1
+            unless on(namespace, persistentvolumeclaim)
+            kube_persistentvolumeclaim_labels{namespace=~"(openshift-.*|kube-.*|default)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
+          for: 1m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubePersistentVolumeFillingUp
+          annotations:
+            description: Based on recent sampling, the PersistentVolume claimed by
+              {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace
+              }} is expected to fill up within four days. Currently {{ $value | humanizePercentage
+              }} is available.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePersistentVolumeFillingUp.md
+            summary: PersistentVolume is filling up.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              kubelet_volume_stats_available_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
+                /
+              kubelet_volume_stats_capacity_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
+            ) < 0.15
+            and
+            kubelet_volume_stats_used_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"} > 0
+            and
+            predict_linear(kubelet_volume_stats_available_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
+            unless on(namespace, persistentvolumeclaim)
+            kube_persistentvolumeclaim_access_mode{namespace=~"(openshift-.*|kube-.*|default)", access_mode="ReadOnlyMany"} == 1
+            unless on(namespace, persistentvolumeclaim)
+            kube_persistentvolumeclaim_labels{namespace=~"(openshift-.*|kube-.*|default)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
+          for: 1h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-kubernetes-system
+      rules:
+        - alert: SYN_KubeClientErrors
+          annotations:
+            description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
+              }}' is experiencing {{ $value | humanizePercentage }} errors.'
+            summary: Kubernetes API server client is experiencing errors.
+            syn_component: openshift4-monitoring
+          expr: |
+            (sum(rate(rest_client_requests_total{code=~"5.."}[5m])) by (instance, job, namespace)
+              /
+            sum(rate(rest_client_requests_total[5m])) by (instance, job, namespace))
+            > 0.01
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-kubernetes-system-apiserver
+      rules:
+        - alert: SYN_KubeAPIDown
+          annotations:
+            description: KubeAPI has disappeared from Prometheus target discovery.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeAPIDown.md
+            summary: Target disappeared from Prometheus target discovery.
+            syn_component: openshift4-monitoring
+          expr: |
+            absent(up{job="apiserver"} == 1)
+          for: 15m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeAPITerminatedRequests
+          annotations:
+            description: The kubernetes apiserver has terminated {{ $value | humanizePercentage
+              }} of its incoming requests.
+            summary: The kubernetes apiserver has terminated {{ $value | humanizePercentage
+              }} of its incoming requests.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m]))  / (  sum(rate(apiserver_request_total{job="apiserver"}[10m])) + sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m])) ) > 0.20
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeAggregatedAPIDown
+          annotations:
+            description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
+              }} has been only {{ $value | humanize }}% available over the last 10m.
+            summary: Kubernetes aggregated API is down.
+            syn_component: openshift4-monitoring
+          expr: |
+            (1 - max by(name, namespace)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 85
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeAggregatedAPIErrors
+          annotations:
+            description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace
+              }} has reported errors. It has appeared unavailable {{ $value | humanize
+              }} times averaged over the past 10m.
+            summary: Kubernetes aggregated API has reported errors.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum by(name, namespace)(increase(aggregator_unavailable_apiservice_total[10m])) > 4
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-kubernetes-system-kubelet
+      rules:
+        - alert: SYN_KubeNodeNotReady
+          annotations:
+            description: '{{ $labels.node }} has been unready for more than 15 minutes.'
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeNodeNotReady.md
+            summary: Node is not ready.
+            syn_component: openshift4-monitoring
+          expr: |
+            kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeNodeReadinessFlapping
+          annotations:
+            description: The readiness status of node {{ $labels.node }} has changed
+              {{ $value }} times in the last 15 minutes.
+            summary: Node readiness status is flapping.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum(changes(kube_node_status_condition{status="true",condition="Ready"}[15m])) by (node) > 2
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeNodeUnreachable
+          annotations:
+            description: '{{ $labels.node }} is unreachable and some workloads may
+              be rescheduled.'
+            summary: Node is unreachable.
+            syn_component: openshift4-monitoring
+          expr: |
+            (kube_node_spec_taint{job="kube-state-metrics",key="node.kubernetes.io/unreachable",effect="NoSchedule"} unless ignoring(key,value) kube_node_spec_taint{job="kube-state-metrics",key=~"ToBeDeletedByClusterAutoscaler|cloud.google.com/impending-node-termination|aws-node-termination-handler/spot-itn"}) == 1
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeletClientCertificateRenewalErrors
+          annotations:
+            description: Kubelet on node {{ $labels.node }} has failed to renew its
+              client certificate ({{ $value | humanize }} errors in the last 5 minutes).
+            summary: Kubelet has failed to renew its client certificate.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(kubelet_certificate_manager_client_expiration_renew_errors[5m]) > 0
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeletDown
+          annotations:
+            description: Kubelet has disappeared from Prometheus target discovery.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeletDown.md
+            summary: Target disappeared from Prometheus target discovery.
+            syn_component: openshift4-monitoring
+          expr: |
+            absent(up{job="kubelet", metrics_path="/metrics"} == 1)
+          for: 15m
+          labels:
+            namespace: kube-system
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeletPlegDurationHigh
+          annotations:
+            description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
+              duration of {{ $value }} seconds on node {{ $labels.node }}.
+            summary: Kubelet Pod Lifecycle Event Generator is taking too long to relist.
+            syn_component: openshift4-monitoring
+          expr: |
+            node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile{quantile="0.99"} >= 10
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeletPodStartUpLatencyHigh
+          annotations:
+            description: Kubelet Pod startup 99th percentile latency is {{ $value
+              }} seconds on node {{ $labels.node }}.
+            summary: Kubelet Pod startup latency is too high.
+            syn_component: openshift4-monitoring
+          expr: |
+            histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by (instance, le)) * on(instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"} > 60
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeletServerCertificateRenewalErrors
+          annotations:
+            description: Kubelet on node {{ $labels.node }} has failed to renew its
+              server certificate ({{ $value | humanize }} errors in the last 5 minutes).
+            summary: Kubelet has failed to renew its server certificate.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(kubelet_server_expiration_renew_errors[5m]) > 0
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeletTooManyPods
+          annotations:
+            description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
+              }} of its Pod capacity.
+            summary: Kubelet is running at capacity.
+            syn_component: openshift4-monitoring
+          expr: |
+            count by(node) (
+              (kube_pod_status_phase{job="kube-state-metrics",phase="Running"} == 1) * on(instance,pod,namespace,cluster) group_left(node) topk by(instance,pod,namespace,cluster) (1, kube_pod_info{job="kube-state-metrics"})
+            )
+            /
+            max by(node) (
+              kube_node_status_capacity{job="kube-state-metrics",resource="pods"} != 1
+            ) > 0.95
+          for: 15m
+          labels:
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-machine-api-operator-metrics-collector-up
+      rules:
+        - alert: SYN_MachineAPIOperatorMetricsCollectionFailing
+          annotations:
+            description: 'For more details:  oc logs <machine-api-operator-pod-name>
+              -n openshift-machine-api'
+            summary: machine api operator metrics collection is failing.
+            syn_component: openshift4-monitoring
+          expr: |
+            mapi_mao_collector_up == 0
+          for: 5m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-machine-health-check-unterminated-short-circuit
+      rules:
+        - alert: SYN_MachineHealthCheckUnterminatedShortCircuit
+          annotations:
+            description: |
+              The number of unhealthy machines has exceeded the `maxUnhealthy` limit for the check, you should check
+              the status of machines in the cluster.
+            summary: machine health check {{ $labels.name }} has been disabled by
+              short circuit for more than 30 minutes
+            syn_component: openshift4-monitoring
+          expr: |
+            mapi_machinehealthcheck_short_circuit == 1
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-machine-not-yet-deleted
+      rules:
+        - alert: SYN_MachineNotYetDeleted
+          annotations:
+            description: |
+              The machine is not properly deleting, this may be due to a configuration issue with the
+              infrastructure provider, or because workloads on the node have PodDisruptionBudgets or
+              long termination periods which are preventing deletion.
+            summary: machine {{ $labels.name }} has been in Deleting phase for more
+              than 6 hours
+            syn_component: openshift4-monitoring
+          expr: |
+            sum by (name, namespace) (avg_over_time(mapi_machine_created_timestamp_seconds{phase="Deleting"}[15m])) > 0
+          for: 360m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-machine-with-no-running-phase
+      rules:
+        - alert: SYN_MachineWithNoRunningPhase
+          annotations:
+            description: |
+              The machine has been without a Running or Deleting phase for more than 60 minutes.
+              The machine may not have been provisioned properly from the infrastructure provider, or
+              it might have issues with CertificateSigningRequests being approved.
+            summary: 'machine {{ $labels.name }} is in phase: {{ $labels.phase }}'
+            syn_component: openshift4-monitoring
+          expr: |
+            (mapi_machine_created_timestamp_seconds{phase!~"Running|Deleting"}) > 0
+          for: 60m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-machine-without-valid-node-ref
+      rules:
+        - alert: SYN_MachineWithoutValidNode
+          annotations:
+            description: |
+              If the machine never became a node, you should diagnose the machine related failures.
+              If the node was deleted from the API, you may delete the machine if appropriate.
+            summary: machine {{ $labels.name }} does not have valid node reference
+            syn_component: openshift4-monitoring
+          expr: |
+            (mapi_machine_created_timestamp_seconds unless on(node) kube_node_info) > 0
+          for: 60m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-master-nodes-high-memory-usage
+      rules:
+        - alert: SYN_MasterNodesHighMemoryUsage
+          annotations:
+            message: Memory usage of {{ $value | humanize }} on {{ $labels.node }}
+              exceeds 90%. Master nodes starved of memory could result in degraded
+              performance of the control plane.
+            syn_component: openshift4-monitoring
+          expr: |
+            ((sum(node_memory_MemTotal_bytes AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )) - sum(node_memory_MemFree_bytes + node_memory_Buffers_bytes + node_memory_Cached_bytes AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" ))) / sum(node_memory_MemTotal_bytes AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )) * 100) > 90
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-mcd-drain-error
+      rules:
+        - alert: SYN_MCDDrainError
+          annotations:
+            message: 'Drain failed on {{ $labels.node }} , updates may be blocked.
+              For more details:  oc logs -f -n {{ $labels.namespace }} {{ $labels.pod
+              }} -c machine-config-daemon'
+            syn_component: openshift4-monitoring
+          expr: |
+            mcd_drain_err > 0
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-mcd-kubelet-health-state-error
+      rules:
+        - alert: SYN_KubeletHealthState
+          annotations:
+            message: Kubelet health failure threshold reached
+            syn_component: openshift4-monitoring
+          expr: |
+            mcd_kubelet_state > 2
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-mcd-pivot-error
+      rules:
+        - alert: SYN_MCDPivotError
+          annotations:
+            message: 'Error detected in pivot logs on {{ $labels.node }} '
+            syn_component: openshift4-monitoring
+          expr: |
+            mcd_pivot_err > 0
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-mcd-reboot-error
+      rules:
+        - alert: SYN_MCDRebootError
+          annotations:
+            message: Reboot failed on {{ $labels.node }} , update may be blocked
+            syn_component: openshift4-monitoring
+          expr: |
+            mcd_reboot_err > 0
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-node-exporter
+      rules:
+        - alert: SYN_NodeClockNotSynchronising
+          annotations:
+            description: Clock on {{ $labels.instance }} is not synchronising. Ensure
+              NTP is configured on this host.
+            summary: Clock not synchronising.
+            syn_component: openshift4-monitoring
+          expr: |
+            min_over_time(node_timex_sync_status[5m]) == 0
+            and
+            node_timex_maxerror_seconds >= 16
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeClockSkewDetected
+          annotations:
+            description: Clock on {{ $labels.instance }} is out of sync by more than
+              300s. Ensure NTP is configured correctly on this host.
+            summary: Clock skew detected.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              node_timex_offset_seconds > 0.05
+            and
+              deriv(node_timex_offset_seconds[5m]) >= 0
+            )
+            or
+            (
+              node_timex_offset_seconds < -0.05
+            and
+              deriv(node_timex_offset_seconds[5m]) <= 0
+            )
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeFileDescriptorLimit
+          annotations:
+            description: File descriptors limit at {{ $labels.instance }} is currently
+              at {{ printf "%.2f" $value }}%.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFileDescriptorLimit.md
+            summary: Kernel is predicted to exhaust file descriptors limit soon.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              node_filefd_allocated{job="node-exporter"} * 100 / node_filefd_maximum{job="node-exporter"} > 70
+            )
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeFileDescriptorLimit
+          annotations:
+            description: File descriptors limit at {{ $labels.instance }} is currently
+              at {{ printf "%.2f" $value }}%.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFileDescriptorLimit.md
+            summary: Kernel is predicted to exhaust file descriptors limit soon.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              node_filefd_allocated{job="node-exporter"} * 100 / node_filefd_maximum{job="node-exporter"} > 90
+            )
+          for: 15m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeFilesystemAlmostOutOfFiles
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available inodes left.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfFiles.md
+            summary: Filesystem has less than 5% inodes left.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 5
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 1h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeFilesystemAlmostOutOfFiles
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available inodes left.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfFiles.md
+            summary: Filesystem has less than 3% inodes left.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 3
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 1h
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeFilesystemAlmostOutOfSpace
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available space left.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+            summary: Filesystem has less than 5% space left.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 5
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 30m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeFilesystemAlmostOutOfSpace
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available space left.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+            summary: Filesystem has less than 3% space left.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 3
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 30m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeFilesystemFilesFillingUp
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available inodes left and is
+              filling up.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
+            summary: Filesystem is predicted to run out of inodes within the next
+              24 hours.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 40
+            and
+              predict_linear(node_filesystem_files_free{job="node-exporter",fstype!=""}[6h], 24*60*60) < 0
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 1h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeFilesystemFilesFillingUp
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available inodes left and is
+              filling up fast.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
+            summary: Filesystem is predicted to run out of inodes within the next
+              4 hours.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 20
+            and
+              predict_linear(node_filesystem_files_free{job="node-exporter",fstype!=""}[6h], 4*60*60) < 0
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 1h
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeFilesystemSpaceFillingUp
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available space left and is
+              filling up.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md
+            summary: Filesystem is predicted to run out of space within the next 24
+              hours.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 15
+            and
+              predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!=""}[6h], 24*60*60) < 0
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 1h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeFilesystemSpaceFillingUp
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available space left and is
+              filling up fast.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md
+            summary: Filesystem is predicted to run out of space within the next 4
+              hours.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 10
+            and
+              predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!=""}[6h], 4*60*60) < 0
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 1h
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeHighNumberConntrackEntriesUsed
+          annotations:
+            description: '{{ $value | humanizePercentage }} of conntrack entries are
+              used.'
+            summary: Number of conntrack are getting close to the limit.
+            syn_component: openshift4-monitoring
+          expr: |
+            (node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeNetworkReceiveErrs
+          annotations:
+            description: '{{ $labels.instance }} interface {{ $labels.device }} has
+              encountered {{ printf "%.0f" $value }} receive errors in the last two
+              minutes.'
+            summary: Network interface is reporting many receive errors.
+            syn_component: openshift4-monitoring
+          expr: |
+            rate(node_network_receive_errs_total[2m]) / rate(node_network_receive_packets_total[2m]) > 0.01
+          for: 1h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeNetworkTransmitErrs
+          annotations:
+            description: '{{ $labels.instance }} interface {{ $labels.device }} has
+              encountered {{ printf "%.0f" $value }} transmit errors in the last two
+              minutes.'
+            summary: Network interface is reporting many transmit errors.
+            syn_component: openshift4-monitoring
+          expr: |
+            rate(node_network_transmit_errs_total[2m]) / rate(node_network_transmit_packets_total[2m]) > 0.01
+          for: 1h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeRAIDDegraded
+          annotations:
+            description: RAID array '{{ $labels.device }}' on {{ $labels.instance
+              }} is in degraded state due to one or more disks failures. Number of
+              spare drives is insufficient to fix issue automatically.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeRAIDDegraded.md
+            summary: RAID Array is degraded
+            syn_component: openshift4-monitoring
+          expr: |
+            node_md_disks_required - ignoring (state) (node_md_disks{state="active"}) > 0
+          for: 15m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeRAIDDiskFailure
+          annotations:
+            description: At least one device in RAID array on {{ $labels.instance
+              }} failed. Array '{{ $labels.device }}' needs attention and possibly
+              a disk swap.
+            summary: Failed device in RAID array
+            syn_component: openshift4-monitoring
+          expr: |
+            node_md_disks{state="failed"} > 0
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_NodeTextFileCollectorScrapeError
+          annotations:
+            description: Node Exporter text file collector failed to scrape.
+            summary: Node Exporter text file collector failed to scrape.
+            syn_component: openshift4-monitoring
+          expr: |
+            node_textfile_scrape_error{job="node-exporter"} == 1
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-node-exporter.rules
+      rules: []
+    - name: syn-node-network
+      rules:
+        - alert: SYN_NodeNetworkInterfaceFlapping
+          annotations:
+            description: Network interface "{{ $labels.device }}" changing its up
+              status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod
+              }}
+            summary: Network interface is often changing its status
+            syn_component: openshift4-monitoring
+          expr: |
+            changes(node_network_up{job="node-exporter",device!~"veth.+"}[2m]) > 2
+          for: 2m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-node-utilization
+      rules:
+        - alert: SYN_node_cpu_load5
+          annotations:
+            message: '{{ $labels.instance }}: Load higher than 2 (current value is:
+              {{ $value }})'
+            syn_component: openshift4-monitoring
+          expr: max by(instance) (node_load5) / count by(instance) (node_cpu_info)
+            > 2
+          for: 30m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_node_memory_free_percent
+          annotations:
+            message: '{{ $labels.node }}: Memory usage more than 97% (current value
+              is: {{ $value | humanizePercentage }})%'
+            syn_component: openshift4-monitoring
+          expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes
+            > 0.97
+          for: 30m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-node.rules
+      rules: []
+    - name: syn-olm.failing_operators.rules
+      rules:
+        - alert: SYN_FailingOperator
+          annotations:
+            message: Failed to install Operator {{ $labels.name }} version {{ $labels.version
+              }}. Reason-{{ $labels.reason }}
+            syn_component: openshift4-monitoring
+          expr: csv_abnormal{phase="Failed"}
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-openshift-build.rules
+      rules: []
+    - name: syn-openshift-etcd-telemetry.rules
+      rules: []
+    - name: syn-openshift-etcd.rules
+      rules:
+        - alert: SYN_etcdGRPCRequestsSlow
+          annotations:
+            description: 'etcd cluster "{{ $labels.job }}": 99th percentile of gRPC
+              requests is {{ $value }}s on etcd instance {{ $labels.instance }} for
+              {{ $labels.grpc_method }} method.'
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdGRPCRequestsSlow.md
+            summary: etcd grpc requests are slow
+            syn_component: openshift4-monitoring
+          expr: |
+            histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_method!="Defragment", grpc_type="unary"}[10m])) without(grpc_type))
+            > 1
+          for: 30m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_etcdHighNumberOfFailedGRPCRequests
+          annotations:
+            description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
+              for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance
+              }}.'
+            summary: etcd cluster has high number of failed grpc requests.
+            syn_component: openshift4-monitoring
+          expr: |
+            (sum(rate(grpc_server_handled_total{job="etcd", grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"}[5m])) without (grpc_type, grpc_code)
+              /
+            (sum(rate(grpc_server_handled_total{job="etcd"}[5m])) without (grpc_type, grpc_code)
+              > 2 and on ()(sum(cluster_infrastructure_provider{type!~"ipi|BareMetal"} == bool 1)))) * 100 > 10
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_etcdHighNumberOfFailedGRPCRequests
+          annotations:
+            description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
+              for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance
+              }}.'
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdHighNumberOfFailedGRPCRequests.md
+            summary: etcd cluster has high number of failed grpc requests.
+            syn_component: openshift4-monitoring
+          expr: |
+            (sum(rate(grpc_server_handled_total{job="etcd", grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"}[5m])) without (grpc_type, grpc_code)
+              /
+            (sum(rate(grpc_server_handled_total{job="etcd"}[5m])) without (grpc_type, grpc_code)
+              > 2 and on ()(sum(cluster_infrastructure_provider{type!~"ipi|BareMetal"} == bool 1)))) * 100 > 50
+          for: 10m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_etcdHighNumberOfLeaderChanges
+          annotations:
+            description: 'etcd cluster "{{ $labels.job }}": {{ $value }} average leader
+              changes within the last 10 minutes. Frequent elections may be a sign
+              of insufficient resources, high network latency, or disruptions by other
+              components and should be investigated.'
+            summary: etcd cluster has high number of leader changes.
+            syn_component: openshift4-monitoring
+          expr: |
+            avg(changes(etcd_server_is_leader[10m])) > 5
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_etcdInsufficientMembers
+          annotations:
+            description: etcd is reporting fewer instances are available than are
+              needed ({{ $value }}). When etcd does not have a majority of instances
+              available the Kubernetes and OpenShift APIs will reject read and write
+              requests and operations that preserve the health of workloads cannot
+              be performed. This can occur when multiple control plane nodes are powered
+              off or are unable to connect to each other via the network. Check that
+              all control plane nodes are powered on and that network connections
+              between each machine are functional.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdInsufficientMembers.md
+            summary: etcd is reporting that a majority of instances are unavailable.
+            syn_component: openshift4-monitoring
+          expr: sum(up{job="etcd"} == bool 1 and etcd_server_has_leader{job="etcd"}
+            == bool 1) without (instance,pod) < ((count(up{job="etcd"}) without (instance,pod)
+            + 1) / 2)
+          for: 3m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-openshift-general.rules
+      rules:
+        - alert: SYN_TargetDown
+          annotations:
+            description: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{
+              $labels.service }} targets in {{ $labels.namespace }} namespace have
+              been unreachable for more than 15 minutes. This may be a symptom of
+              network connectivity issues, down nodes, or failures within these components.
+              Assess the health of the infrastructure and nodes running these targets
+              and then contact support.'
+            summary: Some targets were not reachable from the monitoring server for
+              an extended period of time.
+            syn_component: openshift4-monitoring
+          expr: |
+            100 * (count(up == 0 unless on (node) max by (node) (kube_node_spec_unschedulable == 1)) BY (job, namespace, service) /
+              count(up unless on (node) max by (node) (kube_node_spec_unschedulable == 1)) BY (job, namespace, service)) > 10
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-openshift-ingress.rules
+      rules:
+        - alert: SYN_HAProxyDown
+          annotations:
+            description: This alert fires when metrics report that HAProxy is down.
+            message: HAProxy metrics are reporting that HAProxy is down on pod {{
+              $labels.namespace }} / {{ $labels.pod }}
+            summary: HAProxy is down
+            syn_component: openshift4-monitoring
+          expr: haproxy_up == 0
+          for: 5m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_HAProxyReloadFail
+          annotations:
+            description: This alert fires when HAProxy fails to reload its configuration,
+              which will result in the router not picking up recently created or modified
+              routes.
+            message: HAProxy reloads are failing on {{ $labels.pod }}. Router is not
+              respecting recently created or modified routes
+            summary: HAProxy reload failure
+            syn_component: openshift4-monitoring
+          expr: template_router_reload_failure == 1
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_IngressControllerDegraded
+          annotations:
+            description: This alert fires when the IngressController status is degraded.
+            message: |
+              The {{ $labels.namespace }}/{{ $labels.name }} ingresscontroller is
+              degraded: {{ $labels.reason }}.
+            summary: IngressController is degraded
+            syn_component: openshift4-monitoring
+          expr: ingress_controller_conditions{condition="Degraded"} == 1
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_IngressControllerUnavailable
+          annotations:
+            description: This alert fires when the IngressController is not available.
+            message: |
+              The {{ $labels.namespace }}/{{ $labels.name }} ingresscontroller is
+              unavailable: {{ $labels.reason }}.
+            summary: IngressController is unavailable
+            syn_component: openshift4-monitoring
+          expr: ingress_controller_conditions{condition="Available"} == 0
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-openshift-kubernetes.rules
+      rules:
+        - alert: SYN_AlertmanagerReceiversNotConfigured
+          annotations:
+            description: Alerts are not configured to be sent to a notification system,
+              meaning that you may not be notified in a timely fashion when important
+              failures occur. Check the OpenShift documentation to learn how to configure
+              notifications with Alertmanager.
+            summary: Receivers (notification integrations) are not configured on Alertmanager
+            syn_component: openshift4-monitoring
+          expr: cluster:alertmanager_integrations:max == 0
+          for: 10m
+          labels:
+            namespace: openshift-monitoring
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ClusterMonitoringOperatorReconciliationErrors
+          annotations:
+            description: Errors are occurring during reconciliation cycles. Inspect
+              the cluster-monitoring-operator log for potential root causes.
+            summary: Cluster Monitoring Operator is experiencing unexpected reconciliation
+              errors.
+            syn_component: openshift4-monitoring
+          expr: max_over_time(cluster_monitoring_operator_last_reconciliation_successful[5m])
+            == 0
+          for: 1h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_KubeDeploymentReplicasMismatch
+          annotations:
+            description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
+              }} has not matched the expected number of replicas for longer than 15
+              minutes. This indicates that cluster infrastructure is unable to start
+              or restart the necessary components. This most often occurs when one
+              or more nodes are down or partioned from the cluster, or a fault occurs
+              on the node that prevents the workload from starting. In rare cases
+              this may indicate a new version of a cluster component cannot start
+              due to a bug or configuration error. Assess the pods for this deployment
+              to verify they are running on healthy nodes and then contact support.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeDeploymentReplicasMismatch.md
+            summary: Deployment has not matched the expected number of replicas
+            syn_component: openshift4-monitoring
+          expr: |
+            (((
+              kube_deployment_spec_replicas{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+                >
+              kube_deployment_status_replicas_available{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+            ) and (
+              changes(kube_deployment_status_replicas_updated{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}[5m])
+                ==
+              0
+            )) * on() group_left cluster:control_plane:all_nodes_ready) > 0
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_MultipleContainersOOMKilled
+          annotations:
+            description: Multiple containers were out of memory killed within the
+              past 15 minutes. There are many potential causes of OOM errors, however
+              issues on a specific node or containers breaching their limits is common.
+            summary: Containers are being killed due to OOM
+            syn_component: openshift4-monitoring
+          expr: sum(max by(namespace, container, pod) (increase(kube_pod_container_status_restarts_total[12m]))
+            and max by(namespace, container, pod) (kube_pod_container_status_last_terminated_reason{reason="OOMKilled"})
+            == 1) > 5
+          for: 15m
+          labels:
+            namespace: kube-system
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-openshift-monitoring.rules
+      rules: []
+    - name: syn-openshift-sre.rules
+      rules: []
+    - name: syn-pre-release-lifecycle
+      rules:
+        - alert: SYN_APIRemovedInNextEUSReleaseInUse
+          annotations:
+            description: Deprecated API that will be removed in the next EUS version
+              is being used. Removing the workload that is using the {{ $labels.group
+              }}.{{ $labels.version }}/{{ $labels.resource }} API might be necessary
+              for a successful upgrade to the next EUS cluster version. Refer to `oc
+              get apirequestcounts {{ $labels.resource }}.{{ $labels.version }}.{{
+              $labels.group }} -o yaml` to identify the workload.
+            summary: Deprecated API that will be removed in the next EUS version is
+              being used.
+            syn_component: openshift4-monitoring
+          expr: |
+            group(apiserver_requested_deprecated_apis{removed_release=~"1\\.2[45]"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
+          for: 1h
+          labels:
+            namespace: openshift-kube-apiserver
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_APIRemovedInNextReleaseInUse
+          annotations:
+            description: Deprecated API that will be removed in the next version is
+              being used. Removing the workload that is using the {{ $labels.group
+              }}.{{ $labels.version }}/{{ $labels.resource }} API might be necessary
+              for a successful upgrade to the next cluster version. Refer to `oc get
+              apirequestcounts {{ $labels.resource }}.{{ $labels.version }}.{{ $labels.group
+              }} -o yaml` to identify the workload.
+            summary: Deprecated API that will be removed in the next version is being
+              used.
+            syn_component: openshift4-monitoring
+          expr: |
+            group(apiserver_requested_deprecated_apis{removed_release="1.24"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
+          for: 1h
+          labels:
+            namespace: openshift-kube-apiserver
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-prometheus
+      rules:
+        - alert: SYN_PrometheusBadConfig
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
+              to reload its configuration.
+            summary: Failed Prometheus configuration reload.
+            syn_component: openshift4-monitoring
+          expr: |
+            # Without max_over_time, failed scrapes could create false negatives, see
+            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+            max_over_time(prometheus_config_last_reload_successful{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) == 0
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusDuplicateTimestamps
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
+              {{ printf "%.4g" $value  }} samples/s with different values but duplicated
+              timestamp.
+            summary: Prometheus is dropping samples with duplicate timestamps.
+            syn_component: openshift4-monitoring
+          expr: |
+            rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
+          for: 1h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusErrorSendingAlertsToSomeAlertmanagers
+          annotations:
+            description: '{{ printf "%.1f" $value }}% errors while sending alerts
+              from Prometheus {{$labels.namespace}}/{{$labels.pod}} to Alertmanager
+              {{$labels.alertmanager}}.'
+            summary: Prometheus has encountered more than 1% errors sending alerts
+              to a specific Alertmanager.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              rate(prometheus_notifications_errors_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m])
+            /
+              rate(prometheus_notifications_sent_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m])
+            )
+            * 100
+            > 1
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusLabelLimitHit
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
+              {{ printf "%.0f" $value }} targets because some samples exceeded the
+              configured label_limit, label_name_length_limit or label_value_length_limit.
+            summary: Prometheus has dropped targets because some scrape configs have
+              exceeded the labels limit.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_target_scrape_pool_exceeded_label_limits_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusMissingRuleEvaluations
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
+              {{ printf "%.0f" $value }} rule group evaluations in the last 5m.
+            summary: Prometheus is missing rule evaluations due to slow rule group
+              evaluation.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_rule_group_iterations_missed_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusNotConnectedToAlertmanagers
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
+              to any Alertmanagers.
+            summary: Prometheus is not connected to any Alertmanagers.
+            syn_component: openshift4-monitoring
+          expr: |
+            # Without max_over_time, failed scrapes could create false negatives, see
+            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+            max_over_time(prometheus_notifications_alertmanagers_discovered{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) < 1
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusNotIngestingSamples
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
+              samples.
+            summary: Prometheus is not ingesting samples.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              rate(prometheus_tsdb_head_samples_appended_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) <= 0
+            and
+              (
+                sum without(scrape_job) (prometheus_target_metadata_cache_entries{job=~"prometheus-k8s|prometheus-user-workload"}) > 0
+              or
+                sum without(rule_group) (prometheus_rule_group_rules{job=~"prometheus-k8s|prometheus-user-workload"}) > 0
+              )
+            )
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusNotificationQueueRunningFull
+          annotations:
+            description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
+              is running full.
+            summary: Prometheus alert notification queue predicted to run full in
+              less than 30m.
+            syn_component: openshift4-monitoring
+          expr: |
+            # Without min_over_time, failed scrapes could create false negatives, see
+            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+            (
+              predict_linear(prometheus_notifications_queue_length{job=~"prometheus-k8s|prometheus-user-workload"}[5m], 60 * 30)
+            >
+              min_over_time(prometheus_notifications_queue_capacity{job=~"prometheus-k8s|prometheus-user-workload"}[5m])
+            )
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusOutOfOrderTimestamps
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
+              {{ printf "%.4g" $value  }} samples/s with timestamps arriving out of
+              order.
+            summary: Prometheus drops samples with out-of-order timestamps.
+            syn_component: openshift4-monitoring
+          expr: |
+            rate(prometheus_target_scrapes_sample_out_of_order_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
+          for: 1h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusRemoteStorageFailures
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
+              send {{ printf "%.1f" $value }}% of the samples to {{ $labels.remote_name}}:{{
+              $labels.url }}
+            summary: Prometheus fails to send samples to remote storage.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              (rate(prometheus_remote_storage_failed_samples_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]))
+            /
+              (
+                (rate(prometheus_remote_storage_failed_samples_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]))
+              +
+                (rate(prometheus_remote_storage_succeeded_samples_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) or rate(prometheus_remote_storage_samples_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]))
+              )
+            )
+            * 100
+            > 1
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusRemoteWriteBehind
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
+              is {{ printf "%.1f" $value }}s behind for {{ $labels.remote_name}}:{{
+              $labels.url }}.
+            summary: Prometheus remote write is behind.
+            syn_component: openshift4-monitoring
+          expr: |
+            # Without max_over_time, failed scrapes could create false negatives, see
+            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+            (
+              max_over_time(prometheus_remote_storage_highest_timestamp_in_seconds{job=~"prometheus-k8s|prometheus-user-workload"}[5m])
+            - ignoring(remote_name, url) group_right
+              max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job=~"prometheus-k8s|prometheus-user-workload"}[5m])
+            )
+            > 120
+          for: 15m
+          labels:
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusRemoteWriteDesiredShards
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
+              desired shards calculation wants to run {{ $value }} shards for queue
+              {{ $labels.remote_name}}:{{ $labels.url }}, which is more than the max
+              of {{ printf `prometheus_remote_storage_shards_max{instance="%s",job=~"prometheus-k8s|prometheus-user-workload"}`
+              $labels.instance | query | first | value }}.
+            summary: Prometheus remote write desired shards calculation wants to run
+              more than configured max shards.
+            syn_component: openshift4-monitoring
+          expr: |
+            # Without max_over_time, failed scrapes could create false negatives, see
+            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+            (
+              max_over_time(prometheus_remote_storage_shards_desired{job=~"prometheus-k8s|prometheus-user-workload"}[5m])
+            >
+              max_over_time(prometheus_remote_storage_shards_max{job=~"prometheus-k8s|prometheus-user-workload"}[5m])
+            )
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusRuleFailures
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
+              to evaluate {{ printf "%.0f" $value }} rules in the last 5m.
+            summary: Prometheus is failing rule evaluations.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_rule_evaluation_failures_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusTSDBCompactionsFailing
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
+              {{$value | humanize}} compaction failures over the last 3h.
+            summary: Prometheus has issues compacting blocks.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_tsdb_compactions_failed_total{job=~"prometheus-k8s|prometheus-user-workload"}[3h]) > 0
+          for: 4h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusTSDBReloadsFailing
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
+              {{$value | humanize}} reload failures over the last 3h.
+            summary: Prometheus has issues reloading blocks from disk.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_tsdb_reloads_failures_total{job=~"prometheus-k8s|prometheus-user-workload"}[3h]) > 0
+          for: 4h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusTargetLimitHit
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
+              {{ printf "%.0f" $value }} targets because the number of targets exceeded
+              the configured target_limit.
+            summary: Prometheus has dropped targets because some scrape configs have
+              exceeded the targets limit.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_target_scrape_pool_exceeded_target_limit_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusTargetSyncFailure
+          annotations:
+            description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
+              have failed to sync because invalid configuration was supplied.'
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/PrometheusTargetSyncFailure.md
+            summary: Prometheus has failed to sync targets.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_target_sync_failed_total{job=~"prometheus-k8s|prometheus-user-workload"}[30m]) > 0
+          for: 5m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-prometheus-operator
+      rules:
+        - alert: SYN_PrometheusOperatorListErrors
+          annotations:
+            description: Errors while performing List operations in controller {{$labels.controller}}
+              in {{$labels.namespace}} namespace.
+            summary: Errors while performing list operations in controller.
+            syn_component: openshift4-monitoring
+          expr: |
+            (sum by (controller,namespace) (rate(prometheus_operator_list_operations_failed_total{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_list_operations_total{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[10m]))) > 0.4
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusOperatorNodeLookupErrors
+          annotations:
+            description: Errors while reconciling Prometheus in {{ $labels.namespace
+              }} Namespace.
+            summary: Errors while reconciling Prometheus.
+            syn_component: openshift4-monitoring
+          expr: |
+            rate(prometheus_operator_node_address_lookup_errors_total{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[5m]) > 0.1
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusOperatorNotReady
+          annotations:
+            description: Prometheus operator in {{ $labels.namespace }} namespace
+              isn't ready to reconcile {{ $labels.controller }} resources.
+            summary: Prometheus operator not ready
+            syn_component: openshift4-monitoring
+          expr: |
+            min by(namespace, controller) (max_over_time(prometheus_operator_ready{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[5m]) == 0)
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusOperatorReconcileErrors
+          annotations:
+            description: '{{ $value | humanizePercentage }} of reconciling operations
+              failed for {{ $labels.controller }} controller in {{ $labels.namespace
+              }} namespace.'
+            summary: Errors while reconciling controller.
+            syn_component: openshift4-monitoring
+          expr: |
+            (sum by (controller,namespace) (rate(prometheus_operator_reconcile_errors_total{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[5m]))) / (sum by (controller,namespace) (rate(prometheus_operator_reconcile_operations_total{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[5m]))) > 0.1
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusOperatorRejectedResources
+          annotations:
+            description: Prometheus operator in {{ $labels.namespace }} namespace
+              rejected {{ printf "%0.0f" $value }} {{ $labels.controller }}/{{ $labels.resource
+              }} resources.
+            summary: Resources rejected by Prometheus operator
+            syn_component: openshift4-monitoring
+          expr: |
+            min_over_time(prometheus_operator_managed_resources{state="rejected",job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[5m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusOperatorSyncFailed
+          annotations:
+            description: Controller {{ $labels.controller }} in {{ $labels.namespace
+              }} namespace fails to reconcile {{ $value }} objects.
+            summary: Last controller reconciliation failed
+            syn_component: openshift4-monitoring
+          expr: |
+            min_over_time(prometheus_operator_syncs{status="failed",job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[5m]) > 0
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusOperatorWatchErrors
+          annotations:
+            description: Errors while performing watch operations in controller {{$labels.controller}}
+              in {{$labels.namespace}} namespace.
+            summary: Errors while performing watch operations in controller.
+            syn_component: openshift4-monitoring
+          expr: |
+            (sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[10m]))) > 0.4
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-scheduler-legacy-policy-deprecated
+      rules:
+        - alert: SYN_SchedulerLegacyPolicySet
+          annotations:
+            description: The scheduler is currently configured to use a legacy scheduler
+              policy API. Use of the policy API is deprecated and removed in 4.10.
+            summary: Legacy scheduler policy API in use by the scheduler.
+            syn_component: openshift4-monitoring
+          expr: |
+            cluster_legacy_scheduler_policy > 0
+          for: 60m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-system-memory-exceeds-reservation
+      rules:
+        - alert: SYN_SystemMemoryExceedsReservation
+          annotations:
+            message: System memory usage of {{ $value | humanize }} on {{ $labels.node
+              }} exceeds 95% of the reservation. Reserved memory ensures system processes
+              can function even when the node is fully allocated and protects against
+              workload out of memory events impacting the proper functioning of the
+              node. The default reservation is expected to be sufficient for most
+              configurations and should be increased (https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-managing.html)
+              when running nodes with high numbers of pods (either due to rate of
+              change or at steady state).
+            syn_component: openshift4-monitoring
+          expr: |
+            sum by (node) (container_memory_rss{id="/system.slice"}) > ((sum by (node) (kube_node_status_capacity{resource="memory"} - kube_node_status_allocatable{resource="memory"})) * 0.95)
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-thanos-query
+      rules:
+        - alert: SYN_ThanosQueryGrpcClientErrorRate
+          annotations:
+            description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
+              failing to send {{$value | humanize}}% of requests.
+            summary: Thanos Query is failing to send requests.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              sum by (namespace, job) (rate(grpc_client_handled_total{grpc_code!="OK", job="thanos-querier"}[5m]))
+            /
+              sum by (namespace, job) (rate(grpc_client_started_total{job="thanos-querier"}[5m]))
+            ) * 100 > 5
+          for: 1h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ThanosQueryGrpcServerErrorRate
+          annotations:
+            description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
+              failing to handle {{$value | humanize}}% of requests.
+            summary: Thanos Query is failing to handle requests.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job="thanos-querier"}[5m]))
+            /
+              sum by (namespace, job) (rate(grpc_server_started_total{job="thanos-querier"}[5m]))
+            * 100 > 5
+            )
+          for: 1h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ThanosQueryHighDNSFailures
+          annotations:
+            description: Thanos Query {{$labels.job}} in {{$labels.namespace}} have
+              {{$value | humanize}}% of failing DNS queries for store endpoints.
+            summary: Thanos Query is having high number of DNS failures.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              sum by (namespace, job) (rate(thanos_query_store_apis_dns_failures_total{job="thanos-querier"}[5m]))
+            /
+              sum by (namespace, job) (rate(thanos_query_store_apis_dns_lookups_total{job="thanos-querier"}[5m]))
+            ) * 100 > 1
+          for: 1h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ThanosQueryHttpRequestQueryErrorRateHigh
+          annotations:
+            description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
+              failing to handle {{$value | humanize}}% of "query" requests.
+            summary: Thanos Query is failing to handle requests.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              sum by (namespace, job) (rate(http_requests_total{code=~"5..", job="thanos-querier", handler="query"}[5m]))
+            /
+              sum by (namespace, job) (rate(http_requests_total{job="thanos-querier", handler="query"}[5m]))
+            ) * 100 > 5
+          for: 1h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ThanosQueryHttpRequestQueryRangeErrorRateHigh
+          annotations:
+            description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is
+              failing to handle {{$value | humanize}}% of "query_range" requests.
+            summary: Thanos Query is failing to handle requests.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              sum by (namespace, job) (rate(http_requests_total{code=~"5..", job="thanos-querier", handler="query_range"}[5m]))
+            /
+              sum by (namespace, job) (rate(http_requests_total{job="thanos-querier", handler="query_range"}[5m]))
+            ) * 100 > 5
+          for: 1h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+    - name: syn-thanos-rule
+      rules:
+        - alert: SYN_ThanosNoRuleEvaluations
+          annotations:
+            description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
+              did not perform any rule evaluations in the past 10 minutes.
+            summary: Thanos Rule did not perform any rule evaluations.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job="thanos-ruler"}[5m])) <= 0
+              and
+            sum by (namespace, job, instance) (thanos_rule_loaded_rules{job="thanos-ruler"}) > 0
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ThanosRuleAlertmanagerHighDNSFailures
+          annotations:
+            description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
+              has {{$value | humanize}}% of failing DNS queries for Alertmanager endpoints.
+            summary: Thanos Rule is having high number of DNS failures.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job="thanos-ruler"}[5m]))
+            /
+              sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job="thanos-ruler"}[5m]))
+            * 100 > 1
+            )
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ThanosRuleConfigReloadFailure
+          annotations:
+            description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
+              not been able to reload its configuration.
+            summary: Thanos Rule has not been able to reload configuration.
+            syn_component: openshift4-monitoring
+          expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job="thanos-ruler"})
+            != 1
+          for: 5m
+          labels:
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ThanosRuleGrpcErrorRate
+          annotations:
+            description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} is failing
+              to handle {{$value | humanize}}% of requests.
+            summary: Thanos Rule is failing to handle grpc requests.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job="thanos-ruler"}[5m]))
+            /
+              sum by (namespace, job, instance) (rate(grpc_server_started_total{job="thanos-ruler"}[5m]))
+            * 100 > 5
+            )
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ThanosRuleHighRuleEvaluationFailures
+          annotations:
+            description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
+              is failing to evaluate rules.
+            summary: Thanos Rule is failing to evaluate rules.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job="thanos-ruler"}[5m]))
+            /
+              sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job="thanos-ruler"}[5m]))
+            * 100 > 5
+            )
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ThanosRuleHighRuleEvaluationWarnings
+          annotations:
+            description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
+              has high number of evaluation warnings.
+            summary: Thanos Rule has high number of evaluation warnings.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job="thanos-ruler"}[5m])) > 0
+          for: 15m
+          labels:
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ThanosRuleNoEvaluationFor10Intervals
+          annotations:
+            description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
+              {{$value | humanize}}% rule groups that did not evaluate for at least
+              10x of their expected interval.
+            summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
+            syn_component: openshift4-monitoring
+          expr: |
+            time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job="thanos-ruler"})
+            >
+            10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job="thanos-ruler"})
+          for: 5m
+          labels:
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ThanosRuleQueryHighDNSFailures
+          annotations:
+            description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has
+              {{$value | humanize}}% of failing DNS queries for query endpoints.
+            summary: Thanos Rule is having high number of DNS failures.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job="thanos-ruler"}[5m]))
+            /
+              sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job="thanos-ruler"}[5m]))
+            * 100 > 1
+            )
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ThanosRuleQueueIsDroppingAlerts
+          annotations:
+            description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
+              is failing to queue alerts.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ThanosRuleQueueIsDroppingAlerts.md
+            summary: Thanos Rule is failing to queue alerts.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job="thanos-ruler"}[5m])) > 0
+          for: 5m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ThanosRuleRuleEvaluationLatencyHigh
+          annotations:
+            description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
+              has higher evaluation latency than interval for {{$labels.rule_group}}.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ThanosRuleRuleEvaluationLatencyHigh.md
+            summary: Thanos Rule has high rule evaluation latency.
+            syn_component: openshift4-monitoring
+          expr: |
+            (
+              sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job="thanos-ruler"})
+            >
+              sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job="thanos-ruler"})
+            )
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_ThanosRuleSenderIsFailingAlerts
+          annotations:
+            description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}}
+              is failing to send alerts to alertmanager.
+            summary: Thanos Rule is failing to send alerts to alertmanager.
+            syn_component: openshift4-monitoring
+          expr: |
+            sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job="thanos-ruler"}[5m])) > 0
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/rbac.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/rbac.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    syn_component: openshift4-monitoring
+  labels:
+    name: syn-prometheus-auto-discovery
+  name: syn-prometheus-auto-discovery
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    syn_component: openshift4-monitoring
+  labels:
+    name: syn-prometheus-auto-discovery
+  name: syn-prometheus-auto-discovery
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-prometheus-auto-discovery
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -1,0 +1,107 @@
+apiVersion: v1
+data:
+  silence: |
+    #!/bin/bash
+    set -euo pipefail
+
+    curl_opts=( https://alertmanager-main.openshift-monitoring.svc.cluster.local:9095/api/v2/silences --cacert /etc/ssl/certs/serving-certs/service-ca.crt --header 'Content-Type: application/json' --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" --resolve "alertmanager-main.openshift-monitoring.svc.cluster.local:9095:$(getent hosts alertmanager-operated.openshift-monitoring.svc.cluster.local | awk '{print $1}' | head -n 1)" --silent )
+
+    while IFS= read -r silence; do
+      comment=$(printf %s "${silence}" | jq -r '.comment')
+
+      body=$(printf %s "$silence" | \
+        jq \
+          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S')" \
+          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
+          --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
+          '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
+      )
+
+      id=$(curl "${curl_opts[@]}" | jq -r ".[] | select(.status.state == \"active\") | select(.comment == \"${comment}\") | .id" | head -n 1)
+      if [ -n "${id}" ]; then
+        body=$(printf %s "${body}" | jq --arg id "${id}" '.id = $id')
+      fi
+
+      curl "${curl_opts[@]}" -XPOST -d "${body}"
+    done <<<"$(printf %s "${SILENCES_JSON}" | jq -cr '.[]')"
+  silences.json: '[{"comment":"Silence non syn alerts","matchers":[{"isRegex":true,"name":"alertname","value":".+"},{"isRegex":false,"name":"syn","value":""}]}]'
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: silence
+  name: silence
+  namespace: openshift-monitoring
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: silence
+  name: silence
+  namespace: openshift-monitoring
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: silence
+        spec:
+          containers:
+            - args: []
+              command:
+                - /usr/local/bin/silence
+              env:
+                - name: SILENCES_JSON
+                  valueFrom:
+                    configMapKeyRef:
+                      key: silences.json
+                      name: silence
+              image: quay.io/appuio/oc:v4.12
+              imagePullPolicy: IfNotPresent
+              name: silence
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /etc/ssl/certs/serving-certs/
+                  name: ca-bundle
+                  readOnly: true
+                - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                  name: kube-api-access
+                  readOnly: true
+                - mountPath: /usr/local/bin/silence
+                  name: scripts
+                  readOnly: true
+                  subPath: silence
+          imagePullSecrets: []
+          initContainers: []
+          nodeSelector:
+            node-role.kubernetes.io/infra: ''
+          restartPolicy: Never
+          serviceAccountName: prometheus-k8s
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - configMap:
+                defaultMode: 288
+                name: serving-certs-ca-bundle
+              name: ca-bundle
+            - name: kube-api-access
+              projected:
+                defaultMode: 420
+                sources:
+                  - serviceAccountToken:
+                      expirationSeconds: 3607
+                      path: token
+            - configMap:
+                defaultMode: 360
+                name: silence
+              name: scripts
+  schedule: 0 */4 * * *
+  successfulJobsHistoryLimit: 3

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
@@ -19,10 +19,10 @@ spec:
             message: Only {{ $value }} idle cpu cores accross cluster.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
             syn_component: openshift4-monitoring
-          expr: sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance)
-            group_left label_replace(kube_node_role{role="app"}, "instance", "$1",
-            "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="cpu"})
-            * on(node) group_left kube_node_role{role="app"})
+          expr: sum(label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]),
+            "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"})
+            < 1.000000 * max((kube_node_status_capacity{resource="cpu"}) * on(node)
+            group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -38,9 +38,10 @@ spec:
             message: Only {{ $value }} free memory on Worker Nodes.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
             syn_component: openshift4-monitoring
-          expr: sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"},
-            "instance", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="memory"})
-            * on(node) group_left kube_node_role{role="app"})
+          expr: sum(label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance",
+            "(.+)") * on(node) group_left kube_node_role{role="app"}) < 1.000000 *
+            max((kube_node_status_capacity{resource="memory"}) * on(node) group_left
+            kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -57,9 +58,8 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_capacity{resource="pods"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"},
-            "node", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
+            kube_node_role{role="app"}) - sum(kubelet_running_pods * on(node) group_left
+            kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
             * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
@@ -77,11 +77,9 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            < 1.000000 * max((kube_node_status_allocatable{resource="cpu"}) * on(node)
-            group_left kube_node_role{role="app"})
+            kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="cpu"}
+            * on(node) group_left kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_allocatable{resource="cpu"})
+            * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -96,11 +94,9 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            < 1.000000 * max((kube_node_status_allocatable{resource="memory"}) * on(node)
-            group_left kube_node_role{role="app"})
+            kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="memory"}
+            * on(node) group_left kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_allocatable{resource="memory"})
+            * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -115,29 +111,28 @@ spec:
             message: Cluster has unused nodes.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
             syn_component: openshift4-monitoring
-          expr: |
-            min(
-              (
-                label_replace(
-                  (sum(kube_node_status_capacity{resource="pods"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "pods", "", "")
-              ) or (
-                label_replace(
-                  (sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "requested_memory", "", "")
-              ) or (
-                label_replace(
-                  (sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "requested_cpu", "", "")
-              ) or (
-                label_replace(
-                  sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")) / max((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "memory", "", "")
-              ) or (
-                label_replace(
-                  sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")) / max((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "cpu", "", "")
-              )
+          expr: |-
+            min((
+              label_replace(
+                (sum(kube_node_status_capacity{resource="pods"} * on(node) group_left kube_node_role{role="app"}) - sum(kubelet_running_pods * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "pods", "", "")
+            ) or (
+              label_replace(
+                (sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "requested_memory", "", "")
+            ) or (
+              label_replace(
+                (sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "requested_cpu", "", "")
+            ) or (
+              label_replace(
+                sum(label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}) / max((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "memory", "", "")
+            ) or (
+              label_replace(
+                sum(label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]), "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}) / max((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "cpu", "", "")
+            )
             ) > 4.000000
           for: 8h
           labels:

--- a/tests/golden/es-operator-rules/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
+++ b/tests/golden/es-operator-rules/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
@@ -19,10 +19,10 @@ spec:
             message: Only {{ $value }} idle cpu cores accross cluster.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
             syn_component: openshift4-monitoring
-          expr: sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance)
-            group_left label_replace(kube_node_role{role="app"}, "instance", "$1",
-            "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="cpu"})
-            * on(node) group_left kube_node_role{role="app"})
+          expr: sum(label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]),
+            "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"})
+            < 1.000000 * max((kube_node_status_capacity{resource="cpu"}) * on(node)
+            group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -38,9 +38,10 @@ spec:
             message: Only {{ $value }} free memory on Worker Nodes.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
             syn_component: openshift4-monitoring
-          expr: sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"},
-            "instance", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="memory"})
-            * on(node) group_left kube_node_role{role="app"})
+          expr: sum(label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance",
+            "(.+)") * on(node) group_left kube_node_role{role="app"}) < 1.000000 *
+            max((kube_node_status_capacity{resource="memory"}) * on(node) group_left
+            kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -57,9 +58,8 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_capacity{resource="pods"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"},
-            "node", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
+            kube_node_role{role="app"}) - sum(kubelet_running_pods * on(node) group_left
+            kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
             * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
@@ -77,11 +77,9 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            < 1.000000 * max((kube_node_status_allocatable{resource="cpu"}) * on(node)
-            group_left kube_node_role{role="app"})
+            kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="cpu"}
+            * on(node) group_left kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_allocatable{resource="cpu"})
+            * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -96,11 +94,9 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            < 1.000000 * max((kube_node_status_allocatable{resource="memory"}) * on(node)
-            group_left kube_node_role{role="app"})
+            kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="memory"}
+            * on(node) group_left kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_allocatable{resource="memory"})
+            * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -115,29 +111,28 @@ spec:
             message: Cluster has unused nodes.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
             syn_component: openshift4-monitoring
-          expr: |
-            min(
-              (
-                label_replace(
-                  (sum(kube_node_status_capacity{resource="pods"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "pods", "", "")
-              ) or (
-                label_replace(
-                  (sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "requested_memory", "", "")
-              ) or (
-                label_replace(
-                  (sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "requested_cpu", "", "")
-              ) or (
-                label_replace(
-                  sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")) / max((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "memory", "", "")
-              ) or (
-                label_replace(
-                  sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")) / max((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "cpu", "", "")
-              )
+          expr: |-
+            min((
+              label_replace(
+                (sum(kube_node_status_capacity{resource="pods"} * on(node) group_left kube_node_role{role="app"}) - sum(kubelet_running_pods * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "pods", "", "")
+            ) or (
+              label_replace(
+                (sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "requested_memory", "", "")
+            ) or (
+              label_replace(
+                (sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "requested_cpu", "", "")
+            ) or (
+              label_replace(
+                sum(label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}) / max((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "memory", "", "")
+            ) or (
+              label_replace(
+                sum(label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]), "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}) / max((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "cpu", "", "")
+            )
             ) > 4.000000
           for: 8h
           labels:

--- a/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
+++ b/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
@@ -19,10 +19,10 @@ spec:
             message: Only {{ $value }} idle cpu cores accross cluster.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
             syn_component: openshift4-monitoring
-          expr: sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance)
-            group_left label_replace(kube_node_role{role="app"}, "instance", "$1",
-            "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="cpu"})
-            * on(node) group_left kube_node_role{role="app"})
+          expr: sum(label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]),
+            "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"})
+            < 1.000000 * max((kube_node_status_capacity{resource="cpu"}) * on(node)
+            group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -38,9 +38,10 @@ spec:
             message: Only {{ $value }} free memory on Worker Nodes.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
             syn_component: openshift4-monitoring
-          expr: sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"},
-            "instance", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="memory"})
-            * on(node) group_left kube_node_role{role="app"})
+          expr: sum(label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance",
+            "(.+)") * on(node) group_left kube_node_role{role="app"}) < 1.000000 *
+            max((kube_node_status_capacity{resource="memory"}) * on(node) group_left
+            kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -57,9 +58,8 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_capacity{resource="pods"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"},
-            "node", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
+            kube_node_role{role="app"}) - sum(kubelet_running_pods * on(node) group_left
+            kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
             * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
@@ -77,11 +77,9 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            < 1.000000 * max((kube_node_status_allocatable{resource="cpu"}) * on(node)
-            group_left kube_node_role{role="app"})
+            kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="cpu"}
+            * on(node) group_left kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_allocatable{resource="cpu"})
+            * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -96,11 +94,9 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            < 1.000000 * max((kube_node_status_allocatable{resource="memory"}) * on(node)
-            group_left kube_node_role{role="app"})
+            kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="memory"}
+            * on(node) group_left kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_allocatable{resource="memory"})
+            * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -115,29 +111,28 @@ spec:
             message: Cluster has unused nodes.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
             syn_component: openshift4-monitoring
-          expr: |
-            min(
-              (
-                label_replace(
-                  (sum(kube_node_status_capacity{resource="pods"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "pods", "", "")
-              ) or (
-                label_replace(
-                  (sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "requested_memory", "", "")
-              ) or (
-                label_replace(
-                  (sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "requested_cpu", "", "")
-              ) or (
-                label_replace(
-                  sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")) / max((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "memory", "", "")
-              ) or (
-                label_replace(
-                  sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")) / max((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "cpu", "", "")
-              )
+          expr: |-
+            min((
+              label_replace(
+                (sum(kube_node_status_capacity{resource="pods"} * on(node) group_left kube_node_role{role="app"}) - sum(kubelet_running_pods * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "pods", "", "")
+            ) or (
+              label_replace(
+                (sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "requested_memory", "", "")
+            ) or (
+              label_replace(
+                (sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "requested_cpu", "", "")
+            ) or (
+              label_replace(
+                sum(label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}) / max((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "memory", "", "")
+            ) or (
+              label_replace(
+                sum(label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]), "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}) / max((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "cpu", "", "")
+            )
             ) > 4.000000
           for: 8h
           labels:

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
@@ -19,10 +19,10 @@ spec:
             message: Only {{ $value }} idle cpu cores accross cluster.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
             syn_component: openshift4-monitoring
-          expr: sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance)
-            group_left label_replace(kube_node_role{role="app"}, "instance", "$1",
-            "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="cpu"})
-            * on(node) group_left kube_node_role{role="app"})
+          expr: sum(label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]),
+            "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"})
+            < 1.000000 * max((kube_node_status_capacity{resource="cpu"}) * on(node)
+            group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -38,9 +38,10 @@ spec:
             message: Only {{ $value }} free memory on Worker Nodes.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
             syn_component: openshift4-monitoring
-          expr: sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"},
-            "instance", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="memory"})
-            * on(node) group_left kube_node_role{role="app"})
+          expr: sum(label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance",
+            "(.+)") * on(node) group_left kube_node_role{role="app"}) < 1.000000 *
+            max((kube_node_status_capacity{resource="memory"}) * on(node) group_left
+            kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -57,9 +58,8 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_capacity{resource="pods"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"},
-            "node", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
+            kube_node_role{role="app"}) - sum(kubelet_running_pods * on(node) group_left
+            kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
             * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
@@ -77,11 +77,9 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            < 1.000000 * max((kube_node_status_allocatable{resource="cpu"}) * on(node)
-            group_left kube_node_role{role="app"})
+            kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="cpu"}
+            * on(node) group_left kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_allocatable{resource="cpu"})
+            * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -96,11 +94,9 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            < 1.000000 * max((kube_node_status_allocatable{resource="memory"}) * on(node)
-            group_left kube_node_role{role="app"})
+            kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="memory"}
+            * on(node) group_left kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_allocatable{resource="memory"})
+            * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -115,29 +111,28 @@ spec:
             message: Cluster has unused nodes.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
             syn_component: openshift4-monitoring
-          expr: |
-            min(
-              (
-                label_replace(
-                  (sum(kube_node_status_capacity{resource="pods"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "pods", "", "")
-              ) or (
-                label_replace(
-                  (sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "requested_memory", "", "")
-              ) or (
-                label_replace(
-                  (sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "requested_cpu", "", "")
-              ) or (
-                label_replace(
-                  sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")) / max((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "memory", "", "")
-              ) or (
-                label_replace(
-                  sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")) / max((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "cpu", "", "")
-              )
+          expr: |-
+            min((
+              label_replace(
+                (sum(kube_node_status_capacity{resource="pods"} * on(node) group_left kube_node_role{role="app"}) - sum(kubelet_running_pods * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "pods", "", "")
+            ) or (
+              label_replace(
+                (sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "requested_memory", "", "")
+            ) or (
+              label_replace(
+                (sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "requested_cpu", "", "")
+            ) or (
+              label_replace(
+                sum(label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}) / max((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "memory", "", "")
+            ) or (
+              label_replace(
+                sum(label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]), "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}) / max((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "cpu", "", "")
+            )
             ) > 4.000000
           for: 8h
           labels:

--- a/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
+++ b/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
@@ -19,10 +19,10 @@ spec:
             message: Only {{ $value }} idle cpu cores accross cluster.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
             syn_component: openshift4-monitoring
-          expr: sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance)
-            group_left label_replace(kube_node_role{role="app"}, "instance", "$1",
-            "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="cpu"})
-            * on(node) group_left kube_node_role{role="app"})
+          expr: sum(label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]),
+            "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"})
+            < 1.000000 * max((kube_node_status_capacity{resource="cpu"}) * on(node)
+            group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -38,9 +38,10 @@ spec:
             message: Only {{ $value }} free memory on Worker Nodes.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
             syn_component: openshift4-monitoring
-          expr: sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"},
-            "instance", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="memory"})
-            * on(node) group_left kube_node_role{role="app"})
+          expr: sum(label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance",
+            "(.+)") * on(node) group_left kube_node_role{role="app"}) < 1.000000 *
+            max((kube_node_status_capacity{resource="memory"}) * on(node) group_left
+            kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -57,9 +58,8 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_capacity{resource="pods"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"},
-            "node", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
+            kube_node_role{role="app"}) - sum(kubelet_running_pods * on(node) group_left
+            kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
             * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
@@ -77,11 +77,9 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            < 1.000000 * max((kube_node_status_allocatable{resource="cpu"}) * on(node)
-            group_left kube_node_role{role="app"})
+            kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="cpu"}
+            * on(node) group_left kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_allocatable{resource="cpu"})
+            * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -96,11 +94,9 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            < 1.000000 * max((kube_node_status_allocatable{resource="memory"}) * on(node)
-            group_left kube_node_role{role="app"})
+            kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="memory"}
+            * on(node) group_left kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_allocatable{resource="memory"})
+            * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -115,29 +111,28 @@ spec:
             message: Cluster has unused nodes.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
             syn_component: openshift4-monitoring
-          expr: |
-            min(
-              (
-                label_replace(
-                  (sum(kube_node_status_capacity{resource="pods"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "pods", "", "")
-              ) or (
-                label_replace(
-                  (sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "requested_memory", "", "")
-              ) or (
-                label_replace(
-                  (sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "requested_cpu", "", "")
-              ) or (
-                label_replace(
-                  sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")) / max((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "memory", "", "")
-              ) or (
-                label_replace(
-                  sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")) / max((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "cpu", "", "")
-              )
+          expr: |-
+            min((
+              label_replace(
+                (sum(kube_node_status_capacity{resource="pods"} * on(node) group_left kube_node_role{role="app"}) - sum(kubelet_running_pods * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "pods", "", "")
+            ) or (
+              label_replace(
+                (sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "requested_memory", "", "")
+            ) or (
+              label_replace(
+                (sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "requested_cpu", "", "")
+            ) or (
+              label_replace(
+                sum(label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}) / max((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "memory", "", "")
+            ) or (
+              label_replace(
+                sum(label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]), "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}) / max((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "cpu", "", "")
+            )
             ) > 4.000000
           for: 8h
           labels:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
@@ -19,10 +19,10 @@ spec:
             message: Only {{ $value }} idle cpu cores accross cluster.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
             syn_component: openshift4-monitoring
-          expr: sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance)
-            group_left label_replace(kube_node_role{role="app"}, "instance", "$1",
-            "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="cpu"})
-            * on(node) group_left kube_node_role{role="app"})
+          expr: sum(label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]),
+            "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"})
+            < 1.000000 * max((kube_node_status_capacity{resource="cpu"}) * on(node)
+            group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -38,9 +38,10 @@ spec:
             message: Only {{ $value }} free memory on Worker Nodes.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
             syn_component: openshift4-monitoring
-          expr: sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"},
-            "instance", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="memory"})
-            * on(node) group_left kube_node_role{role="app"})
+          expr: sum(label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance",
+            "(.+)") * on(node) group_left kube_node_role{role="app"}) < 1.000000 *
+            max((kube_node_status_capacity{resource="memory"}) * on(node) group_left
+            kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -57,9 +58,8 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_capacity{resource="pods"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"},
-            "node", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
+            kube_node_role{role="app"}) - sum(kubelet_running_pods * on(node) group_left
+            kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
             * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
@@ -77,11 +77,9 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            < 1.000000 * max((kube_node_status_allocatable{resource="cpu"}) * on(node)
-            group_left kube_node_role{role="app"})
+            kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="cpu"}
+            * on(node) group_left kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_allocatable{resource="cpu"})
+            * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -96,11 +94,9 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            < 1.000000 * max((kube_node_status_allocatable{resource="memory"}) * on(node)
-            group_left kube_node_role{role="app"})
+            kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="memory"}
+            * on(node) group_left kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_allocatable{resource="memory"})
+            * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -115,29 +111,28 @@ spec:
             message: Cluster has unused nodes.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
             syn_component: openshift4-monitoring
-          expr: |
-            min(
-              (
-                label_replace(
-                  (sum(kube_node_status_capacity{resource="pods"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "pods", "", "")
-              ) or (
-                label_replace(
-                  (sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "requested_memory", "", "")
-              ) or (
-                label_replace(
-                  (sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "requested_cpu", "", "")
-              ) or (
-                label_replace(
-                  sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")) / max((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "memory", "", "")
-              ) or (
-                label_replace(
-                  sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")) / max((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "cpu", "", "")
-              )
+          expr: |-
+            min((
+              label_replace(
+                (sum(kube_node_status_capacity{resource="pods"} * on(node) group_left kube_node_role{role="app"}) - sum(kubelet_running_pods * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "pods", "", "")
+            ) or (
+              label_replace(
+                (sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "requested_memory", "", "")
+            ) or (
+              label_replace(
+                (sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "requested_cpu", "", "")
+            ) or (
+              label_replace(
+                sum(label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}) / max((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "memory", "", "")
+            ) or (
+              label_replace(
+                sum(label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]), "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}) / max((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "cpu", "", "")
+            )
             ) > 4.000000
           for: 8h
           labels:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/capacity_rules.yaml
@@ -19,10 +19,10 @@ spec:
             message: Only {{ $value }} idle cpu cores accross cluster.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/cpucapacity.html#SYN_ClusterCpuUsageHigh
             syn_component: openshift4-monitoring
-          expr: sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance)
-            group_left label_replace(kube_node_role{role="app"}, "instance", "$1",
-            "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="cpu"})
-            * on(node) group_left kube_node_role{role="app"})
+          expr: sum(label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]),
+            "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"})
+            < 1.000000 * max((kube_node_status_capacity{resource="cpu"}) * on(node)
+            group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -38,9 +38,10 @@ spec:
             message: Only {{ $value }} free memory on Worker Nodes.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/memorycapacity.html#SYN_ClusterMemoryUsageHigh
             syn_component: openshift4-monitoring
-          expr: sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"},
-            "instance", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="memory"})
-            * on(node) group_left kube_node_role{role="app"})
+          expr: sum(label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance",
+            "(.+)") * on(node) group_left kube_node_role{role="app"}) < 1.000000 *
+            max((kube_node_status_capacity{resource="memory"}) * on(node) group_left
+            kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -57,9 +58,8 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/podcapacity.html#SYN_TooManyPods
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_capacity{resource="pods"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"},
-            "node", "$1", "node", "(.+)")) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
+            kube_node_role{role="app"}) - sum(kubelet_running_pods * on(node) group_left
+            kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_capacity{resource="pods"})
             * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
@@ -77,11 +77,9 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchCPURequested
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            < 1.000000 * max((kube_node_status_allocatable{resource="cpu"}) * on(node)
-            group_left kube_node_role{role="app"})
+            kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="cpu"}
+            * on(node) group_left kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_allocatable{resource="cpu"})
+            * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -96,11 +94,9 @@ spec:
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/resourcerequests.html#SYN_TooMuchMemoryRequested
             syn_component: openshift4-monitoring
           expr: sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left
-            label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))
-            < 1.000000 * max((kube_node_status_allocatable{resource="memory"}) * on(node)
-            group_left kube_node_role{role="app"})
+            kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="memory"}
+            * on(node) group_left kube_node_role{role="app"}) < 1.000000 * max((kube_node_status_allocatable{resource="memory"})
+            * on(node) group_left kube_node_role{role="app"})
           for: 30m
           labels:
             severity: warning
@@ -115,29 +111,28 @@ spec:
             message: Cluster has unused nodes.
             runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/unusedcapacity.html#SYN_ClusterHasUnusedNodes
             syn_component: openshift4-monitoring
-          expr: |
-            min(
-              (
-                label_replace(
-                  (sum(kube_node_status_capacity{resource="pods"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kubelet_running_pods * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "pods", "", "")
-              ) or (
-                label_replace(
-                  (sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "requested_memory", "", "")
-              ) or (
-                label_replace(
-                  (sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)")) - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left label_replace(kube_node_role{role="app"}, "node", "$1", "node", "(.+)"))) / max((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "requested_cpu", "", "")
-              ) or (
-                label_replace(
-                  sum(node_memory_MemAvailable_bytes * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")) / max((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "memory", "", "")
-              ) or (
-                label_replace(
-                  sum(rate(node_cpu_seconds_total{mode="idle"}[15m]) * on(instance) group_left label_replace(kube_node_role{role="app"}, "instance", "$1", "node", "(.+)")) / max((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
-                , "resource", "cpu", "", "")
-              )
+          expr: |-
+            min((
+              label_replace(
+                (sum(kube_node_status_capacity{resource="pods"} * on(node) group_left kube_node_role{role="app"}) - sum(kubelet_running_pods * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_capacity{resource="pods"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "pods", "", "")
+            ) or (
+              label_replace(
+                (sum(kube_node_status_allocatable{resource="memory"} * on(node) group_left kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="memory"} * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_allocatable{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "requested_memory", "", "")
+            ) or (
+              label_replace(
+                (sum(kube_node_status_allocatable{resource="cpu"} * on(node) group_left kube_node_role{role="app"}) - sum(kube_pod_resource_request{resource="cpu"} * on(node) group_left kube_node_role{role="app"})) / max((kube_node_status_allocatable{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "requested_cpu", "", "")
+            ) or (
+              label_replace(
+                sum(label_replace(node_memory_MemAvailable_bytes, "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}) / max((kube_node_status_capacity{resource="memory"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "memory", "", "")
+            ) or (
+              label_replace(
+                sum(label_replace(rate(node_cpu_seconds_total{mode="idle"}[15m]), "node", "$1", "instance", "(.+)") * on(node) group_left kube_node_role{role="app"}) / max((kube_node_status_capacity{resource="cpu"}) * on(node) group_left kube_node_role{role="app"})
+              , "resource", "cpu", "", "")
+            )
             ) > 4.000000
           for: 8h
           labels:


### PR DESCRIPTION
With this change, we can give a list of node labels to the component to make it segregate the generated capacity alerts by node label. If the list is empty (default), the generated alerts are functionally equivalent to before.

My change in the alert generation logic caused all alerts to change slightly, but the resulting metrics are equivalent. I only removed no-op relabelings, and in some expressions where relabeling is actually required, I moved it to the other side of the operator (e.g. instead of relabeling `node` to `instance` on the LHS, I'm relabeling `instance` to `node` on the RHS).


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
