### PR TITLE
Allow remoteWrite for user workload monitoring to be configured in hierarchy

### DIFF
--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -194,6 +194,40 @@ This table shows the monitoring components you can configure and the keys used t
 |Thanos Ruler|`thanosRuler`|
 |====
 
+=== `configsUserWorkload.prometheus._remoteWrite`
+
+[horizontal]
+type:: dictionary
+default:: `{}`
+example::
++
+[source,yaml]
+----
+_remoteWrite:
+  example:
+    url: https://prometheus.example.com/api/v1/write
+    headers:
+      "X-Scope-OrgID": customer
+    writeRelabelConfigs:
+      - sourceLabels: ['customer']
+        regex: '.+'
+        action: keep
+    basicAuth:
+      username:
+        name: remote-write-customer
+        key: username
+      password:
+        name: remote-write-customer
+        key: password
+----
+
+A dictionary holding the remote write configurations for the Prometheus component of the user workload monitoring stack.
+The key is the name of the configuration, the value is the content of the configuration.
+
+The remote write configuration will be appended to the `configsUserWorkload.prometheus.remoteWrite` parameter for backwards compatibility.
+
+
+
 == `alertManagerConfig`
 
 [horizontal]

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
@@ -14,6 +14,7 @@ data:
     "prometheus":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
@@ -14,6 +14,7 @@ data:
     "prometheus":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/es-operator-rules/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
+++ b/tests/golden/es-operator-rules/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
@@ -14,6 +14,7 @@ data:
     "prometheus":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
+++ b/tests/golden/release-4.10/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
@@ -14,6 +14,7 @@ data:
     "prometheus":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
@@ -14,6 +14,7 @@ data:
     "prometheus":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
+++ b/tests/golden/release-4.9/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
@@ -14,6 +14,7 @@ data:
     "prometheus":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/01_secrets.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/01_secrets.yaml
@@ -10,3 +10,17 @@ stringData:
   password: prometheus
   username: prometheus
 type: Opaque
+---
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: remote-write-user
+  name: remote-write-user
+  namespace: openshift-user-workload-monitoring
+stringData:
+  password: prometheus
+  username: prometheus
+type: Opaque

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
@@ -14,6 +14,24 @@ data:
     "prometheus":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+      "remoteWrite":
+      - "name": "backwards-compatibility-user"
+      - "basicAuth":
+          "password":
+            "key": "password"
+            "name": "remote-write-user"
+          "username":
+            "key": "username"
+            "name": "remote-write-user"
+        "headers":
+          "X-Scope-OrgID": "customer"
+        "name": "example"
+        "url": "https://user-prometheus.example.com/api/v1/write"
+        "writeRelabelConfigs":
+        - "action": "keep"
+          "regex": ".+"
+          "sourceLabels":
+          - "customer"
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
@@ -14,6 +14,7 @@ data:
     "prometheus":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/10_configmap_user_workload.yaml
@@ -14,6 +14,7 @@ data:
     "prometheus":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/remote-write.yml
+++ b/tests/remote-write.yml
@@ -16,6 +16,12 @@ parameters:
         stringData:
           username: prometheus
           password: prometheus
+      remote-write-user:
+        metadata:
+          namespace: openshift-user-workload-monitoring
+        stringData:
+          username: prometheus
+          password: prometheus
 
     configs:
       prometheusK8s:
@@ -36,4 +42,25 @@ parameters:
                 key: username
               password:
                 name: remote-write
+                key: password
+
+    configsUserWorkload:
+      prometheus:
+        remoteWrite:
+          - name: backwards-compatibility-user
+        _remoteWrite:
+          example:
+            url: https://user-prometheus.example.com/api/v1/write
+            headers:
+              "X-Scope-OrgID": customer
+            writeRelabelConfigs:
+              - sourceLabels: ['customer']
+                regex: '.+'
+                action: keep
+            basicAuth:
+              username:
+                name: remote-write-user
+                key: username
+              password:
+                name: remote-write-user
                 key: password


### PR DESCRIPTION
This PR allows us to configure remote write for the user workload monitoring stack. Works the same way as the feature introduced in https://github.com/appuio/component-openshift4-monitoring/pull/125.

As context we'd like to use this as AppCat collects some metrics through the user-workload monitoring stack to allow users to define their own alerting rules, but we'd still like to ship some of these metrics to central monitoring.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
