### PR TITLE
Add option to configure timeseries as a list instead of regex in relabel config

### DIFF
--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -141,9 +141,13 @@ _remoteWrite:
     headers:
       "X-Scope-OrgID": example
     writeRelabelConfigs:
-      - sourceLabels: ['syn']
+      - action: keep
+        sourceLabels: ['syn']
         regex: '.+'
-        action: keep
+      - action: keep
+        timeseries:
+          - foo_metric_one
+          - foo_metric_two
     basicAuth:
       username:
         name: remote-write
@@ -158,6 +162,8 @@ The key is the name of the configuration, the value is the content of the config
 
 The remote write configuration will be appended to the `configs.prometheusK8s.remoteWrite` parameter for backwards compatibility.
 
+In this configuration only, `writeRelabelConfigs` entries can hold an entry for `timeseries` containing a list of strings representing individual Prometheus timeseries.
+These will be translated into a `regex` entry, with a regular expression matching any one of the listed timeseries.
 
 == `configsUserWorkload`
 

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -46,6 +46,11 @@ data:
           "regex": ".+"
           "sourceLabels":
           - "syn"
+        - "action": "keep"
+          "regex": "(foo_metric_number_one|foo_metric_number_two)"
+        - "action": "keep"
+          "sourceLabels":
+          - "foo"
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/remote-write.yml
+++ b/tests/remote-write.yml
@@ -36,6 +36,15 @@ parameters:
               - sourceLabels: ['syn']
                 regex: '.+'
                 action: keep
+              - timeseries:
+                  - foo_metric_number_one
+                  - foo_metric_number_two
+                  - foo_metric_number_three
+                  - ~foo_metric_number_three
+                action: keep
+              - timeseries: []
+                sourceLabels: ['foo']
+                action: keep
             basicAuth:
               username:
                 name: remote-write


### PR DESCRIPTION
## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
