### PR TITLE
Add support for `alerts.customAnnotations` in the alert-patching library

### DIFF
--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -167,15 +167,8 @@ local annotateRules = {
               // rules cannot have annotations.
               // We identify alert rules by the presence of the `alert` field.
               if std.objectHas(rule, 'alert') then
-                local annotations =
-                  defaultAnnotations +
-                  if std.objectHas(customAnnotations, rule.alert) then
-                    customAnnotations[rule.alert]
-                  else
-                    {};
-
                 rule {
-                  annotations+: annotations,
+                  annotations+: defaultAnnotations,
                 }
               else
                 rule,

--- a/docs/modules/ROOT/pages/references/alert-patching.adoc
+++ b/docs/modules/ROOT/pages/references/alert-patching.adoc
@@ -84,6 +84,8 @@ If `preserveRecordingRules` is `false`, all recording rules are also removed fro
 This function patches the provided alert rule to adhere to the format expected by this component.
 This includes adding labels which are used by other parts of the component to the rule (for example `syn=true`), and ensuring that the alert name is prefixed with `SYN_`.
 
+The function also reads any custom annotations from parameter `openshift4_monitoring.alerts.customAnnotations` and applies those to the alert rule.
+
 Custom alert patches can be provided through argument `patches`.
 
 Recording rules will always be returned unchanged.


### PR DESCRIPTION
We also remove the previous code which injects
`alerts.customAnnotations` in `rules.jsonnet`, since we call `patchRule()` for each alert managed through this component anyway.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
