### PR TITLE
Remove parameter `upstreamRules.clusterSamplesOperator`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -28,7 +28,6 @@ parameters:
     enableUserWorkload: true
     upstreamRules:
       networkPlugin: openshift-sdn
-      clusterSamplesOperator: true
     configs:
       prometheusK8s:
         remoteWrite: []

--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -23,10 +23,6 @@ local upstreamManifestsFileExclude = function(file) (
     file == 'openshift-sdn.yaml'
   )
   || (
-    params.upstreamRules.clusterSamplesOperator == false &&
-    file == 'cluster-samples-operator.yaml'
-  )
-  || (
     inv.parameters.facts.cloud != 'vsphere' &&
     file == 'vsphere-problem-detector-rules.yaml'
   )

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -46,15 +46,6 @@ Choose either `openshift-sdn` or `ovn-kubernetes` depending on the installed net
 If a custom network plugin is used, set any other string as the value for this parameter.
 This ensures neither openshift-sdn nor OVN-Kubernetes monitoring rules are deployed.
 
-== `upstreamRules.clusterSamplesOperator`
-
-[horizontal]
-type:: boolean
-default:: `true`
-
-Whether the Cluster Samples Operator prometheus rules should be included or not.
-
-
 == `enableUserWorkload`
 
 [horizontal]


### PR DESCRIPTION
The parameter is not needed anymore with parameter `alerts.ignoreGroups`, where we ignore the `SamplesOperator` group by default.

Follow-up to #159 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
