### PR TITLE
Introduce parameter which allows patching alerts for all OCP4 versions

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -151,7 +151,9 @@ parameters:
         - kube-apiserver-slos-basic
       customAnnotations: {}
       patchRules:
-        release-4.11:
+        # rules patched in '*' will be applied regardless of the value of
+        # parameter `manifests_version`.
+        '*':
           HighOverallControlPlaneMemory:
             annotations:
               description: |
@@ -186,6 +188,9 @@ parameters:
           PrometheusRemoteWriteDesiredShards:
             annotations:
               runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/remotewrite.html
+        release-4.11: {}
+        release-4.12: {}
+        release-4.13: {}
       # Alerts to ignore for user workload monitoring
       ignoreUserWorkload: []
 

--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -138,11 +138,12 @@ local patchExpr(expr) =
   );
 
 local rulePatches =
-  com.getValueOrDefault(
+  std.get(params.alerts.patchRules, '*', {}) +
+  com.makeMergeable(std.get(
     params.alerts.patchRules,
     params.manifests_version,
     {}
-  );
+  ));
 
 local patchRules = {
   spec+: {

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -329,14 +329,19 @@ customAnnotations:
 
 === `patchRules`
 type:: dict
-keys:: potential values of parameter `manifests_versions`
+keys:: potential values of parameter `manifests_versions` and `*`
 default:: See https://github.com/appuio/component-openshift4-monitoring/blob/master/class/defaults.yml[`class/defaults.yml` on GitHub]
 
 The parameter `patchRules` allows users to customize upstream alerts.
 The component expects that top-level keys in the parameter correspond to values of parameter `manifests_versions`.
-This enables users to selectively patch upstream alerts for a particular OpenShift 4 version.
+Additionally, the component supports special top-level key `*`.
 
-For each version, the component expects alert names as keys and any alert configuration as values.
+Alert patches which are defined under top-level key `*` are applied regardless of the OpenShift 4 version specified in parameter `manifest_versions`.
+Additionally, the component applies all patches under they key which matches the value of parameter `manifest_versions`.
+If an alert is patched in both top-level key `*` and the top-level key matching parameter `manifest_versions`, the patches are merged together, with the version-specific patch overriding the generic patch.
+
+
+The component expects alert names as keys and any alert configuration as values in each top-level key.
 See the Prometheus https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/[alerting rules documentation] for extended documentation on configuring alerting rules.
 
 Example:
@@ -344,7 +349,11 @@ Example:
 [source,yaml]
 ----
 patchRules:
-  release-4.9:
+  '*':
+    PrometheusRemoteWriteBehind:
+      annotations:
+        runbook_url: https://example.com/runbooks/PrometheusRemoteWriteBehind.html
+  release-4.11:
     SystemMemoryExceedsReservation:
       for: 30m
 ----

--- a/tests/custom-rules.yml
+++ b/tests/custom-rules.yml
@@ -13,6 +13,19 @@ parameters:
   openshift4_monitoring:
     manifests_version: release-4.11
 
+    alerts:
+      patchRules:
+        '*':
+          HighOverallControlPlaneMemory:
+            labels:
+              foo: foo
+              generic: patch
+        release-4.11:
+          HighOverallControlPlaneMemory:
+            labels:
+              foo: bar
+              specific: patch
+
     rules:
       group-a:
         "record:foo:sum":

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -559,10 +559,16 @@ spec:
       rules:
         - alert: SYN_HighOverallControlPlaneMemory
           annotations:
-            description: Given three control plane nodes, the overall memory utilization
-              may only be about 2/3 of all available capacity. This is because if
-              a single control plane node fails, the kube-apiserver and etcd my be
-              slow to respond. To fix this, increase memory of the control plane nodes.
+            description: |
+              The overall memory usage is high.
+              kube-apiserver and etcd might be slow to respond.
+              To fix this, increase memory of the control plane nodes.
+
+              This alert was adjusted to be less sensitive in 4.11.
+              Newer Go versions use more memory, if available, to reduce GC pauses.
+
+              Old memory behavior can be restored by setting `GOGC=63`.
+              See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
             summary: Memory utilization across all control plane nodes is high, and
               could impact responsiveness and stability.
             syn_component: openshift4-monitoring
@@ -581,7 +587,7 @@ spec:
                 AND on (instance)
                 label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
               )
-            ) * 100 > 60
+            ) * 100 > 80
           for: 1h
           labels:
             namespace: openshift-machine-config-operator
@@ -2005,6 +2011,7 @@ spec:
               {{ $labels.remote_name}}:{{ $labels.url }}, which is more than the max
               of {{ printf `prometheus_remote_storage_shards_max{instance="%s",job=~"prometheus-k8s|prometheus-user-workload"}`
               $labels.instance | query | first | value }}.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/remotewrite.html
             summary: Prometheus remote write desired shards calculation wants to run
               more than configured max shards.
             syn_component: openshift4-monitoring

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -559,10 +559,16 @@ spec:
       rules:
         - alert: SYN_HighOverallControlPlaneMemory
           annotations:
-            description: Given three control plane nodes, the overall memory utilization
-              may only be about 2/3 of all available capacity. This is because if
-              a single control plane node fails, the kube-apiserver and etcd my be
-              slow to respond. To fix this, increase memory of the control plane nodes.
+            description: |
+              The overall memory usage is high.
+              kube-apiserver and etcd might be slow to respond.
+              To fix this, increase memory of the control plane nodes.
+
+              This alert was adjusted to be less sensitive in 4.11.
+              Newer Go versions use more memory, if available, to reduce GC pauses.
+
+              Old memory behavior can be restored by setting `GOGC=63`.
+              See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
             summary: Memory utilization across all control plane nodes is high, and
               could impact responsiveness and stability.
             syn_component: openshift4-monitoring
@@ -581,7 +587,7 @@ spec:
                 AND on (instance)
                 label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
               )
-            ) * 100 > 60
+            ) * 100 > 80
           for: 1h
           labels:
             namespace: openshift-machine-config-operator
@@ -2005,6 +2011,7 @@ spec:
               {{ $labels.remote_name}}:{{ $labels.url }}, which is more than the max
               of {{ printf `prometheus_remote_storage_shards_max{instance="%s",job=~"prometheus-k8s|prometheus-user-workload"}`
               $labels.instance | query | first | value }}.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/remotewrite.html
             summary: Prometheus remote write desired shards calculation wants to run
               more than configured max shards.
             syn_component: openshift4-monitoring

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -566,7 +566,10 @@ spec:
             ) * 100 > 80
           for: 1h
           labels:
+            foo: bar
+            generic: patch
             severity: warning
+            specific: patch
             syn: 'true'
             syn_component: openshift4-monitoring
     - name: syn-kube-state-metrics

--- a/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -539,10 +539,16 @@ spec:
       rules:
         - alert: SYN_HighOverallControlPlaneMemory
           annotations:
-            description: Given three control plane nodes, the overall memory utilization
-              may only be about 2/3 of all available capacity. This is because if
-              a single control plane node fails, the kube-apiserver and etcd my be
-              slow to respond. To fix this, increase memory of the control plane nodes.
+            description: |
+              The overall memory usage is high.
+              kube-apiserver and etcd might be slow to respond.
+              To fix this, increase memory of the control plane nodes.
+
+              This alert was adjusted to be less sensitive in 4.11.
+              Newer Go versions use more memory, if available, to reduce GC pauses.
+
+              Old memory behavior can be restored by setting `GOGC=63`.
+              See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
             summary: Memory utilization across all control plane nodes is high, and
               could impact responsiveness and stability.
             syn_component: openshift4-monitoring
@@ -561,7 +567,7 @@ spec:
                 AND on (instance)
                 label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
               )
-            ) * 100 > 60
+            ) * 100 > 80
           for: 1h
           labels:
             severity: warning
@@ -2003,6 +2009,7 @@ spec:
               {{ $labels.remote_name}}:{{ $labels.url }}, which is more than the max
               of {{ printf `prometheus_remote_storage_shards_max{instance="%s",job=~"prometheus-k8s|prometheus-user-workload"}`
               $labels.instance | query | first | value }}.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/remotewrite.html
             summary: Prometheus remote write desired shards calculation wants to run
               more than configured max shards.
             syn_component: openshift4-monitoring

--- a/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -559,10 +559,16 @@ spec:
       rules:
         - alert: SYN_HighOverallControlPlaneMemory
           annotations:
-            description: Given three control plane nodes, the overall memory utilization
-              may only be about 2/3 of all available capacity. This is because if
-              a single control plane node fails, the kube-apiserver and etcd my be
-              slow to respond. To fix this, increase memory of the control plane nodes.
+            description: |
+              The overall memory usage is high.
+              kube-apiserver and etcd might be slow to respond.
+              To fix this, increase memory of the control plane nodes.
+
+              This alert was adjusted to be less sensitive in 4.11.
+              Newer Go versions use more memory, if available, to reduce GC pauses.
+
+              Old memory behavior can be restored by setting `GOGC=63`.
+              See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
             summary: Memory utilization across all control plane nodes is high, and
               could impact responsiveness and stability.
             syn_component: openshift4-monitoring
@@ -581,7 +587,7 @@ spec:
                 AND on (instance)
                 label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
               )
-            ) * 100 > 60
+            ) * 100 > 80
           for: 1h
           labels:
             namespace: openshift-machine-config-operator
@@ -2005,6 +2011,7 @@ spec:
               {{ $labels.remote_name}}:{{ $labels.url }}, which is more than the max
               of {{ printf `prometheus_remote_storage_shards_max{instance="%s",job=~"prometheus-k8s|prometheus-user-workload"}`
               $labels.instance | query | first | value }}.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/remotewrite.html
             summary: Prometheus remote write desired shards calculation wants to run
               more than configured max shards.
             syn_component: openshift4-monitoring

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -559,10 +559,16 @@ spec:
       rules:
         - alert: SYN_HighOverallControlPlaneMemory
           annotations:
-            description: Given three control plane nodes, the overall memory utilization
-              may only be about 2/3 of all available capacity. This is because if
-              a single control plane node fails, the kube-apiserver and etcd my be
-              slow to respond. To fix this, increase memory of the control plane nodes.
+            description: |
+              The overall memory usage is high.
+              kube-apiserver and etcd might be slow to respond.
+              To fix this, increase memory of the control plane nodes.
+
+              This alert was adjusted to be less sensitive in 4.11.
+              Newer Go versions use more memory, if available, to reduce GC pauses.
+
+              Old memory behavior can be restored by setting `GOGC=63`.
+              See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
             summary: Memory utilization across all control plane nodes is high, and
               could impact responsiveness and stability.
             syn_component: openshift4-monitoring
@@ -581,7 +587,7 @@ spec:
                 AND on (instance)
                 label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
               )
-            ) * 100 > 60
+            ) * 100 > 80
           for: 1h
           labels:
             namespace: openshift-machine-config-operator
@@ -2005,6 +2011,7 @@ spec:
               {{ $labels.remote_name}}:{{ $labels.url }}, which is more than the max
               of {{ printf `prometheus_remote_storage_shards_max{instance="%s",job=~"prometheus-k8s|prometheus-user-workload"}`
               $labels.instance | query | first | value }}.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/remotewrite.html
             summary: Prometheus remote write desired shards calculation wants to run
               more than configured max shards.
             syn_component: openshift4-monitoring

--- a/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -588,10 +588,16 @@ spec:
       rules:
         - alert: SYN_HighOverallControlPlaneMemory
           annotations:
-            description: Given three control plane nodes, the overall memory utilization
-              may only be about 2/3 of all available capacity. This is because if
-              a single control plane node fails, the kube-apiserver and etcd my be
-              slow to respond. To fix this, increase memory of the control plane nodes.
+            description: |
+              The overall memory usage is high.
+              kube-apiserver and etcd might be slow to respond.
+              To fix this, increase memory of the control plane nodes.
+
+              This alert was adjusted to be less sensitive in 4.11.
+              Newer Go versions use more memory, if available, to reduce GC pauses.
+
+              Old memory behavior can be restored by setting `GOGC=63`.
+              See https://bugzilla.redhat.com/show_bug.cgi?id=2074031 for more details.
             summary: Memory utilization across all control plane nodes is high, and
               could impact responsiveness and stability.
             syn_component: openshift4-monitoring
@@ -610,7 +616,7 @@ spec:
                 AND on (instance)
                 label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
               )
-            ) * 100 > 60
+            ) * 100 > 80
           for: 1h
           labels:
             namespace: openshift-machine-config-operator
@@ -2117,6 +2123,7 @@ spec:
               {{ $labels.remote_name}}:{{ $labels.url }}, which is more than the max
               of {{ printf `prometheus_remote_storage_shards_max{instance="%s",job=~"prometheus-k8s|prometheus-user-workload"}`
               $labels.instance | query | first | value }}.
+            runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/remotewrite.html
             summary: Prometheus remote write desired shards calculation wants to run
               more than configured max shards.
             syn_component: openshift4-monitoring


### PR DESCRIPTION
We introduce parameter `alerts.patchRules."*"` which allows users to patch alerts regardless of the value of `manifests_version`. This will make managing custom alert patchsets (e.g. for marking alerts as maintenance or on-call relevant) easier.

We also move the patches which are defined in `class/defaults.yml` to the new parameter, since they are applicable for all currently supported OpenShift 4 versions.

Note that it's possible to patch an alert both for all versions and for a specific version, in which case, the patches get merged, with the version-specific patch having higher priority.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
