### PR TITLE
Add 1min time overlap for silence cronjob

### DIFF
--- a/component/scripts/silence.sh
+++ b/component/scripts/silence.sh
@@ -8,7 +8,7 @@ while IFS= read -r silence; do
 
   body=$(printf %s "$silence" | \
     jq \
-      --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S')" \
+      --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
       --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
       --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
       '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -11,7 +11,7 @@ data:
 
       body=$(printf %s "$silence" | \
         jq \
-          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S')" \
+          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
           --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -11,7 +11,7 @@ data:
 
       body=$(printf %s "$silence" | \
         jq \
-          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S')" \
+          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
           --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -11,7 +11,7 @@ data:
 
       body=$(printf %s "$silence" | \
         jq \
-          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S')" \
+          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
           --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -11,7 +11,7 @@ data:
 
       body=$(printf %s "$silence" | \
         jq \
-          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S')" \
+          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
           --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'

--- a/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -11,7 +11,7 @@ data:
 
       body=$(printf %s "$silence" | \
         jq \
-          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S')" \
+          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
           --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'

--- a/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -11,7 +11,7 @@ data:
 
       body=$(printf %s "$silence" | \
         jq \
-          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S')" \
+          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
           --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -11,7 +11,7 @@ data:
 
       body=$(printf %s "$silence" | \
         jq \
-          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S')" \
+          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
           --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'

--- a/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -11,7 +11,7 @@ data:
 
       body=$(printf %s "$silence" | \
         jq \
-          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S')" \
+          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
           --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -11,7 +11,7 @@ data:
 
       body=$(printf %s "$silence" | \
         jq \
-          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S')" \
+          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
           --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -11,7 +11,7 @@ data:
 
       body=$(printf %s "$silence" | \
         jq \
-          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S')" \
+          --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
           --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'


### PR DESCRIPTION
In the rare case that a node clock isn't properly synchronized, the new silence can start slightly after the existing one is already expired. This leads to unnecessary alerts. 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
