### PR TITLE
Respect existing `syn_team` labels when patching alerts

### DIFF
--- a/lib/openshift4-monitoring-alert-patching.libsonnet
+++ b/lib/openshift4-monitoring-alert-patching.libsonnet
@@ -152,7 +152,7 @@ local patchRule(rule, patches={}, patchName=true) =
         syn_component: inv.parameters._instance,
         // mark alert as belonging to the team in whose context the
         // function is called.
-        [if syn_team != '' then 'syn_team']: syn_team,
+        [if syn_team != '' && !std.objectHas(super.labels, 'syn_team') then 'syn_team']: syn_team,
       },
       annotations+:
         std.get(global_alert_params.customAnnotations, super.alert, {}),

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -806,7 +806,7 @@ spec:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
               }} has not matched the expected number of replicas for longer than 15
               minutes.
-            summary: Deployment has not matched the expected number of replicas.
+            summary: StatefulSet has not matched the expected number of replicas.
             syn_component: openshift4-monitoring
           expr: |
             (

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -806,7 +806,7 @@ spec:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
               }} has not matched the expected number of replicas for longer than 15
               minutes.
-            summary: Deployment has not matched the expected number of replicas.
+            summary: StatefulSet has not matched the expected number of replicas.
             syn_component: openshift4-monitoring
           expr: |
             (

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -809,7 +809,7 @@ spec:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
               }} has not matched the expected number of replicas for longer than 15
               minutes.
-            summary: Deployment has not matched the expected number of replicas.
+            summary: StatefulSet has not matched the expected number of replicas.
             syn_component: openshift4-monitoring
           expr: |
             (

--- a/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -785,7 +785,7 @@ spec:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
               }} has not matched the expected number of replicas for longer than 15
               minutes.
-            summary: Deployment has not matched the expected number of replicas.
+            summary: StatefulSet has not matched the expected number of replicas.
             syn_component: openshift4-monitoring
           expr: |
             (

--- a/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -806,7 +806,7 @@ spec:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
               }} has not matched the expected number of replicas for longer than 15
               minutes.
-            summary: Deployment has not matched the expected number of replicas.
+            summary: StatefulSet has not matched the expected number of replicas.
             syn_component: openshift4-monitoring
           expr: |
             (

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -806,7 +806,7 @@ spec:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
               }} has not matched the expected number of replicas for longer than 15
               minutes.
-            summary: Deployment has not matched the expected number of replicas.
+            summary: StatefulSet has not matched the expected number of replicas.
             syn_component: openshift4-monitoring
           expr: |
             (

--- a/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/custom_rules.yaml
+++ b/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/custom_rules.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: custom-rules
+  name: custom-rules
+spec:
+  groups:
+    - name: my-rules
+      rules:
+        - alert: MyAlert
+          annotations: {}
+          expr: vector(1)
+          labels:
+            syn: 'true'
+            syn_component: openshift4-monitoring
+            syn_team: yet_another_team

--- a/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -848,7 +848,7 @@ spec:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
               }} has not matched the expected number of replicas for longer than 15
               minutes.
-            summary: Deployment has not matched the expected number of replicas.
+            summary: StatefulSet has not matched the expected number of replicas.
             syn_component: openshift4-monitoring
           expr: |
             (

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -806,7 +806,7 @@ spec:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
               }} has not matched the expected number of replicas for longer than 15
               minutes.
-            summary: Deployment has not matched the expected number of replicas.
+            summary: StatefulSet has not matched the expected number of replicas.
             syn_component: openshift4-monitoring
           expr: |
             (

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -806,7 +806,7 @@ spec:
             description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
               }} has not matched the expected number of replicas for longer than 15
               minutes.
-            summary: Deployment has not matched the expected number of replicas.
+            summary: StatefulSet has not matched the expected number of replicas.
             syn_component: openshift4-monitoring
           expr: |
             (

--- a/tests/team-label.yml
+++ b/tests/team-label.yml
@@ -18,3 +18,11 @@ parameters:
       other_team:
         instances:
           - 'openshift4-monitoring'
+
+  openshift4_monitoring:
+    rules:
+      my-rules:
+        "alert:MyAlert":
+          expr: 'vector(1)'
+          labels:
+            syn_team: yet_another_team


### PR DESCRIPTION


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
