### PR TITLE
Correctly handle alerts with no labels

### DIFF
--- a/lib/openshift4-monitoring-alert-patching.libsonnet
+++ b/lib/openshift4-monitoring-alert-patching.libsonnet
@@ -140,6 +140,12 @@ local patchRule(rule, patches={}, patchName=true) =
         'SYN_' + name
       else
         name;
+    local syn_team_label =
+      if std.objectHas(rule, 'labels') && std.objectHas(rule.labels, 'syn_team')
+      then
+        rule.labels.syn_team
+      else
+        syn_team;
     rule {
       // Change alert names so we don't get multiple alerts with the same
       // name, as the logging operator deploys its own copy of these
@@ -152,7 +158,7 @@ local patchRule(rule, patches={}, patchName=true) =
         syn_component: inv.parameters._instance,
         // mark alert as belonging to the team in whose context the
         // function is called.
-        [if syn_team != '' && !std.objectHas(super.labels, 'syn_team') then 'syn_team']: syn_team,
+        [if syn_team_label != '' then 'syn_team']: syn_team_label,
       },
       annotations+:
         std.get(global_alert_params.customAnnotations, super.alert, {}),

--- a/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/custom_rules.yaml
+++ b/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/custom_rules.yaml
@@ -16,3 +16,10 @@ spec:
             syn: 'true'
             syn_component: openshift4-monitoring
             syn_team: yet_another_team
+        - alert: NoLabels
+          annotations: {}
+          expr: vector(1)
+          labels:
+            syn: 'true'
+            syn_component: openshift4-monitoring
+            syn_team: other_team

--- a/tests/team-label.yml
+++ b/tests/team-label.yml
@@ -26,3 +26,5 @@ parameters:
           expr: 'vector(1)'
           labels:
             syn_team: yet_another_team
+        "alert:NoLabels":
+          expr: 'vector(1)'


### PR DESCRIPTION


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
