### PR TITLE
Block gossip traffic between alertmanagers in different namespaces

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -30,6 +30,8 @@ parameters:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
     enableUserWorkload: true
+    enableAlertmanagerIsolationNetworkPolicy: true
+    enableUserWorkloadAlertmanagerIsolationNetworkPolicy: true
     upstreamRules:
       networkPlugin: openshift-sdn
     configs:

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -108,6 +108,8 @@ local customRules =
       'alertmanager.yaml': std.manifestYamlDoc(params.alertManagerConfig),
     },
   },
+  [if params.enableAlertmanagerIsolationNetworkPolicy then '20_networkpolicy']: std.map(function(p) com.namespaced('openshift-monitoring', p), import 'networkpolicy.libsonnet'),
+  [if params.enableUserWorkload && params.enableUserWorkloadAlertmanagerIsolationNetworkPolicy then '20_user_workload_networkpolicy']: std.map(function(p) com.namespaced('openshift-user-workload-monitoring', p), import 'networkpolicy.libsonnet'),
   rbac: import 'rbac.libsonnet',
   prometheus_rules: rules,
   silence: import 'silence.jsonnet',

--- a/component/networkpolicy.libsonnet
+++ b/component/networkpolicy.libsonnet
@@ -66,16 +66,8 @@ local params = inv.parameters.openshift4_monitoring;
   },
   kube.NetworkPolicy('allow-non-alertmanager') {
     spec: {
-      ingress: [
-        {
-          from: [
-            {
-              podSelector: {},
-              namespaceSelector: {},
-            },
-          ],
-        },
-      ],
+      // from https://kubernetes.io/docs/concepts/services-networking/network-policies/#allow-all-ingress-traffic
+      ingress: [ {} ],
       policyTypes: [
         'Ingress',
       ],

--- a/component/networkpolicy.libsonnet
+++ b/component/networkpolicy.libsonnet
@@ -1,0 +1,95 @@
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_monitoring;
+
+[
+  kube.NetworkPolicy('alertmanager-allow-web') {
+    spec: {
+      podSelector: {
+        matchLabels: {
+          'app.kubernetes.io/name': 'alertmanager',
+        },
+      },
+      policyTypes: [
+        'Ingress',
+      ],
+      ingress: [
+        {
+          ports: [
+            {
+              protocol: 'TCP',
+              port: 9092,
+            },
+            {
+              protocol: 'TCP',
+              port: 9093,
+            },
+            {
+              protocol: 'TCP',
+              port: 9095,
+            },
+            {
+              protocol: 'TCP',
+              port: 9097,
+            },
+          ],
+        },
+        {
+          from: [
+            {
+              namespaceSelector: {},
+            },
+          ],
+        },
+      ],
+    },
+  },
+  kube.NetworkPolicy('allow-same-namespace') {
+    spec: {
+      ingress: [
+        {
+          from: [
+            {
+              podSelector: {},
+            },
+          ],
+        },
+      ],
+      policyTypes: [
+        'Ingress',
+      ],
+      podSelector: {},
+    },
+  },
+  kube.NetworkPolicy('allow-non-alertmanager') {
+    spec: {
+      ingress: [
+        {
+          from: [
+            {
+              podSelector: {},
+              namespaceSelector: {},
+            },
+          ],
+        },
+      ],
+      policyTypes: [
+        'Ingress',
+      ],
+      podSelector: {
+        matchExpressions: [
+          {
+            key: 'app.kubernetes.io/name',
+            operator: 'NotIn',
+            values: [
+              'alertmanager',
+            ],
+          },
+        ],
+      },
+    },
+  },
+]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -46,6 +46,29 @@ Choose either `openshift-sdn` or `ovn-kubernetes` depending on the installed net
 If a custom network plugin is used, set any other string as the value for this parameter.
 This ensures neither openshift-sdn nor OVN-Kubernetes monitoring rules are deployed.
 
+
+== `enableAlertmanagerIsolationNetworkPolicy`
+
+[horizontal]
+type:: boolean
+default:: `true`
+
+Blocks all traffic to Alertmanager pods except the allowed API traffic.
+
+This works around an observed accidental clustering with user workload or custom Alertmanager clusters in other namespaces.
+
+
+== `enableUserWorkloadAlertmanagerIsolationNetworkPolicy`
+
+[horizontal]
+type:: boolean
+default:: `true`
+
+Blocks all traffic to Alertmanager pods except the allowed API traffic.
+
+This works around an observed accidental clustering with system or custom Alertmanager clusters in other namespaces.
+
+
 == `enableUserWorkload`
 
 [horizontal]

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-user-workload-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-user-workload-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-user-workload-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-user-workload-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-user-workload-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-user-workload-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-user-workload-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/team-label/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-user-workload-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-user-workload-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/20_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: alertmanager-allow-web
+  name: alertmanager-allow-web
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9095
+          protocol: TCP
+        - port: 9097
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-same-namespace
+  name: allow-same-namespace
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-non-alertmanager
+  name: allow-non-alertmanager
+  namespace: openshift-user-workload-monitoring
+spec:
+  ingress:
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - alertmanager
+  policyTypes:
+    - Ingress

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/20_user_workload_networkpolicy.yaml
@@ -51,9 +51,7 @@ metadata:
   namespace: openshift-user-workload-monitoring
 spec:
   ingress:
-    - from:
-        - namespaceSelector: {}
-          podSelector: {}
+    - {}
   podSelector:
     matchExpressions:
       - key: app.kubernetes.io/name


### PR DESCRIPTION
Alertmanager sometimes did build a cluster with customer installed AMs or the user workload monitoring AMs.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
