### PR TITLE
Allow using alert patching library in post process filters

### DIFF
--- a/lib/openshift4-monitoring-alert-patching.libsonnet
+++ b/lib/openshift4-monitoring-alert-patching.libsonnet
@@ -2,9 +2,7 @@
 // arbitrary alert rules to adhere to the format required by the component's
 // approach for allowing us to patch upstream rules.
 local com = import 'lib/commodore.libjsonnet';
-local kap = import 'lib/kapitan.libjsonnet';
-
-local inv = kap.inventory();
+local inv = com.inventory();
 
 local global_alert_params =
   local p =


### PR DESCRIPTION
Tested to work both in component jsonnet and post-process jsonnet with a recent commodore version.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
