### PR TITLE
Fix `filterRules` failing when using `preserveRecordingRules`

### DIFF
--- a/lib/openshift4-monitoring-alert-patching.libsonnet
+++ b/lib/openshift4-monitoring-alert-patching.libsonnet
@@ -81,20 +81,17 @@ local syn_team =
  *    is `false`, all recording rules are also removed from the result.
  */
 local filterRules(group, ignoreNames=[], preserveRecordingRules=false) =
-  local filterRecording(rule) =
-    if preserveRecordingRules then
-      true
-    else
-      // only create duplicates of alert rules
-      std.objectHas(rule, 'alert');
   local ignore_set = std.set(global_alert_params.ignoreNames + ignoreNames);
   group {
     rules:
       std.filter(
         // Filter out unwanted rules
         function(rule)
-          filterRecording(rule) &&
-          !std.member(ignore_set, rule.alert),
+          local isAlert = std.objectHas(rule, 'alert');
+          if isAlert then
+            !std.member(ignore_set, rule.alert)
+          else
+            preserveRecordingRules,
         super.rules
       ),
   };


### PR DESCRIPTION


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
