### PR TITLE
Add parameter `alerts.excludeNamespaces` to exclude specific namespaces from base alerts

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -116,6 +116,7 @@ parameters:
         - kube-.*
         - openshift-.*
         - syn.*
+      excludeNamespaces: []
       ignoreNames:
         - AlertmanagerReceiversNotConfigured
         - CannotRetrieveUpdates

--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -130,11 +130,30 @@ local annotateRules = {
 local renderedNamespaceSelector =
   std.join('|', com.renderArray(params.alerts.includeNamespaces));
 
+local renderedExcludesSelector =
+  std.join('|', com.renderArray(params.alerts.excludeNamespaces));
+
+local renderedSelector =
+  local hasNsSel = std.length(renderedNamespaceSelector) > 0;
+  local hasExcSel = std.length(renderedExcludesSelector) > 0;
+  (
+    if hasNsSel then
+      'namespace=~"(%s)"' % renderedNamespaceSelector
+    else ''
+
+  ) + (
+    if hasNsSel && hasExcSel then ',' else ''
+  ) + (
+    if std.length(renderedExcludesSelector) > 0 then
+      'namespace!~"(%s)"' % renderedExcludesSelector
+    else ''
+  );
+
 local patchExpr(expr) =
   std.strReplace(
     expr,
     'namespace=~"(openshift-.*|kube-.*|default)"',
-    'namespace=~"(%s)"' % renderedNamespaceSelector
+    renderedSelector
   );
 
 local rulePatches =

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -353,7 +353,7 @@ default:: https://github.com/appuio/component-openshift4-monitoring/blob/master/
 
 List of namespace patterns to use for alerts which have `namespace=~"(openshift-.\*|kube-.*|default)"` in the upstream rule.
 The component generates a regex pattern from the list by concatenating all elements into a large OR-regex.
-To inject the custom regex, the component searches for the exact string `namespace=~"(openshift-.\*|kube-.*|default)"` in field `expr` of each alert rule and replaces it with the regex generated from the parameter.
+To inject the custom regex, the component searches for the exact string `namespace=~"(openshift-.\*|kube-.*|default)"` in field `expr` of each alert rule and replaces it with the regex generated from this parameter and parameter `excludeNamespaces`.
 
 The component processes the list with `com.renderArray()` to allow users to drop entries in the hierarchy.
 
@@ -371,6 +371,36 @@ includeNamespaces:
 ----
 
 The component will generate namespace selector `namespace=~"(default|syn.*)"` from this input configuration.
+
+=== `excludeNamespaces`
+
+[horizontal]
+type:: list
+default:: `[]`
+
+List of namespace patterns to exclude for alerts which have `namespace=~"(openshift-.\*|kube-.*|default)"` in the upstream rule.
+The component generates a regex pattern from the list by concatenating all elements into a large OR-regex.
+To inject the custom regex, the component searches for the exact string `namespace=~"(openshift-.\*|kube-.*|default)"` in field `expr` of each alert rule and replaces it with the regex generated from this parameter and parameter `includeNamespaces`.
+
+The component processes the list with `com.renderArray()` to allow users to drop entries in the hierarchy.
+
+IMPORTANT: The component doesn't validate that the list entries are valid regex patterns.
+
+==== Example
+
+We assume that the input config has patterns `default` and `openshift.*` and `syn.*` for `includeNamespaces` and `openshift-adp` for `excludeNamespaces`:
+
+[source,yaml]
+----
+includeNamespaces:
+  - default
+  - openshift.*
+  - syn.*
+excludeNamespaces:
+  - openshift-adp
+----
+
+The component will generate namespace selector `namespace=~"(default|openshift.*|syn.*)",namespace!~"(openshift-adp)"` from this input configuration.
 
 === `ignoreNames`
 

--- a/tests/custom-rules.yml
+++ b/tests/custom-rules.yml
@@ -14,6 +14,8 @@ parameters:
     manifests_version: release-4.13
 
     alerts:
+      excludeNamespaces:
+        - openshift-adp
       patchRules:
         '*':
           HighOverallControlPlaneMemory:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -626,7 +626,7 @@ spec:
             summary: Pod container waiting longer than 1 hour
             syn_component: openshift4-monitoring
           expr: |
-            sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}) > 0
+            sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}) > 0
           for: 1h
           labels:
             severity: warning
@@ -639,7 +639,7 @@ spec:
             summary: DaemonSet pods are misscheduled.
             syn_component: openshift4-monitoring
           expr: |
-            kube_daemonset_status_number_misscheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"} > 0
+            kube_daemonset_status_number_misscheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"} > 0
           for: 15m
           labels:
             severity: warning
@@ -652,9 +652,9 @@ spec:
             summary: DaemonSet pods are not scheduled.
             syn_component: openshift4-monitoring
           expr: |
-            kube_daemonset_status_desired_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+            kube_daemonset_status_desired_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
               -
-            kube_daemonset_status_current_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"} > 0
+            kube_daemonset_status_current_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"} > 0
           for: 10m
           labels:
             severity: warning
@@ -669,24 +669,24 @@ spec:
           expr: |
             (
               (
-                kube_daemonset_status_current_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+                kube_daemonset_status_current_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
                  !=
-                kube_daemonset_status_desired_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+                kube_daemonset_status_desired_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
               ) or (
-                kube_daemonset_status_number_misscheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+                kube_daemonset_status_number_misscheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
                  !=
                 0
               ) or (
-                kube_daemonset_status_updated_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+                kube_daemonset_status_updated_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
                  !=
-                kube_daemonset_status_desired_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+                kube_daemonset_status_desired_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
               ) or (
-                kube_daemonset_status_number_available{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+                kube_daemonset_status_number_available{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
                  !=
-                kube_daemonset_status_desired_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+                kube_daemonset_status_desired_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
               )
             ) and (
-              changes(kube_daemonset_status_updated_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}[5m])
+              changes(kube_daemonset_status_updated_number_scheduled{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}[5m])
                 ==
               0
             )
@@ -703,9 +703,9 @@ spec:
             summary: Deployment generation mismatch due to possible roll-back
             syn_component: openshift4-monitoring
           expr: |
-            kube_deployment_status_observed_generation{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+            kube_deployment_status_observed_generation{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
               !=
-            kube_deployment_metadata_generation{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+            kube_deployment_metadata_generation{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
           for: 15m
           labels:
             severity: warning
@@ -718,7 +718,7 @@ spec:
             summary: Deployment rollout is not progressing.
             syn_component: openshift4-monitoring
           expr: |
-            kube_deployment_status_condition{condition="Progressing", status="false",namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+            kube_deployment_status_condition{condition="Progressing", status="false",namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
             != 0
           for: 15m
           labels:
@@ -734,7 +734,7 @@ spec:
             summary: Job failed to complete.
             syn_component: openshift4-monitoring
           expr: |
-            kube_job_failed{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}  > 0
+            kube_job_failed{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}  > 0
           for: 15m
           labels:
             severity: warning
@@ -747,9 +747,9 @@ spec:
             summary: Job did not complete in time
             syn_component: openshift4-monitoring
           expr: |
-            time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+            time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
               and
-            kube_job_status_active{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"} > 0) > 43200
+            kube_job_status_active{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"} > 0) > 43200
           labels:
             severity: warning
             syn: 'true'
@@ -761,7 +761,7 @@ spec:
             summary: Pod is crash looping.
             syn_component: openshift4-monitoring
           expr: |
-            max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}[5m]) >= 1
+            max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}[5m]) >= 1
           for: 15m
           labels:
             severity: warning
@@ -777,7 +777,7 @@ spec:
           expr: |
             sum by (namespace, pod, cluster) (
               max by(namespace, pod, cluster) (
-                kube_pod_status_phase{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)", job="kube-state-metrics", phase=~"Pending|Unknown"}
+                kube_pod_status_phase{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)", job="kube-state-metrics", phase=~"Pending|Unknown"}
                 unless ignoring(phase) (kube_pod_status_unschedulable{job="kube-state-metrics"} == 1)
               ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
                 1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
@@ -796,9 +796,9 @@ spec:
             summary: StatefulSet generation mismatch due to possible roll-back
             syn_component: openshift4-monitoring
           expr: |
-            kube_statefulset_status_observed_generation{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+            kube_statefulset_status_observed_generation{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
               !=
-            kube_statefulset_metadata_generation{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+            kube_statefulset_metadata_generation{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
           for: 15m
           labels:
             severity: warning
@@ -813,11 +813,11 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (
-              kube_statefulset_status_replicas_ready{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+              kube_statefulset_status_replicas_ready{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
                 !=
-              kube_statefulset_status_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+              kube_statefulset_status_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
             ) and (
-              changes(kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}[10m])
+              changes(kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}[10m])
                 ==
               0
             )
@@ -835,18 +835,18 @@ spec:
           expr: |
             (
               max without (revision) (
-                kube_statefulset_status_current_revision{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+                kube_statefulset_status_current_revision{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
                   unless
-                kube_statefulset_status_update_revision{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+                kube_statefulset_status_update_revision{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
               )
                 *
               (
-                kube_statefulset_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+                kube_statefulset_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
                   !=
-                kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+                kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
               )
             )  and (
-              changes(kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}[5m])
+              changes(kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}[5m])
                 ==
               0
             )
@@ -864,7 +864,7 @@ spec:
             summary: PersistentVolume is having issues with provisioning.
             syn_component: openshift4-monitoring
           expr: |
-            kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"} > 0
+            kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"} > 0
           for: 5m
           labels:
             severity: warning
@@ -880,16 +880,16 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (
-              kubelet_volume_stats_available_bytes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kubelet", metrics_path="/metrics"}
+              kubelet_volume_stats_available_bytes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kubelet", metrics_path="/metrics"}
                 /
-              kubelet_volume_stats_capacity_bytes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kubelet", metrics_path="/metrics"}
+              kubelet_volume_stats_capacity_bytes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kubelet", metrics_path="/metrics"}
             ) < 0.03
             and
-            kubelet_volume_stats_used_bytes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kubelet", metrics_path="/metrics"} > 0
+            kubelet_volume_stats_used_bytes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kubelet", metrics_path="/metrics"} > 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
+            kube_persistentvolumeclaim_labels{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
           for: 1m
           labels:
             severity: critical
@@ -906,18 +906,18 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (
-              kubelet_volume_stats_available_bytes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kubelet", metrics_path="/metrics"}
+              kubelet_volume_stats_available_bytes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kubelet", metrics_path="/metrics"}
                 /
-              kubelet_volume_stats_capacity_bytes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kubelet", metrics_path="/metrics"}
+              kubelet_volume_stats_capacity_bytes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kubelet", metrics_path="/metrics"}
             ) < 0.15
             and
-            kubelet_volume_stats_used_bytes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kubelet", metrics_path="/metrics"} > 0
+            kubelet_volume_stats_used_bytes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kubelet", metrics_path="/metrics"} > 0
             and
-            predict_linear(kubelet_volume_stats_available_bytes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kubelet", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
+            predict_linear(kubelet_volume_stats_available_bytes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kubelet", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
+            kube_persistentvolumeclaim_labels{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
           for: 1h
           labels:
             severity: warning
@@ -933,16 +933,16 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (
-              kubelet_volume_stats_inodes_free{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kubelet", metrics_path="/metrics"}
+              kubelet_volume_stats_inodes_free{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kubelet", metrics_path="/metrics"}
                 /
-              kubelet_volume_stats_inodes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kubelet", metrics_path="/metrics"}
+              kubelet_volume_stats_inodes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kubelet", metrics_path="/metrics"}
             ) < 0.03
             and
-            kubelet_volume_stats_inodes_used{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kubelet", metrics_path="/metrics"} > 0
+            kubelet_volume_stats_inodes_used{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kubelet", metrics_path="/metrics"} > 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
+            kube_persistentvolumeclaim_labels{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
           for: 1m
           labels:
             severity: critical
@@ -959,18 +959,18 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (
-              kubelet_volume_stats_inodes_free{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kubelet", metrics_path="/metrics"}
+              kubelet_volume_stats_inodes_free{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kubelet", metrics_path="/metrics"}
                 /
-              kubelet_volume_stats_inodes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kubelet", metrics_path="/metrics"}
+              kubelet_volume_stats_inodes{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kubelet", metrics_path="/metrics"}
             ) < 0.15
             and
-            kubelet_volume_stats_inodes_used{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kubelet", metrics_path="/metrics"} > 0
+            kubelet_volume_stats_inodes_used{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kubelet", metrics_path="/metrics"} > 0
             and
-            predict_linear(kubelet_volume_stats_inodes_free{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kubelet", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
+            predict_linear(kubelet_volume_stats_inodes_free{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kubelet", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
+            kube_persistentvolumeclaim_labels{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
           for: 1h
           labels:
             severity: warning
@@ -1789,11 +1789,11 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (((
-              kube_deployment_spec_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+              kube_deployment_spec_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
                 >
-              kube_deployment_status_replicas_available{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
+              kube_deployment_status_replicas_available{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
             ) and (
-              changes(kube_deployment_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}[5m])
+              changes(kube_deployment_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}[5m])
                 ==
               0
             )) * on() group_left cluster:control_plane:all_nodes_ready) > 0
@@ -1810,7 +1810,7 @@ spec:
               oc describe -n {{ $labels.namespace }} pod {{ $labels.pod }}
             summary: Pod cannot be scheduled.
             syn_component: openshift4-monitoring
-          expr: last_over_time(kube_pod_status_unschedulable{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)"}[5m])
+          expr: last_over_time(kube_pod_status_unschedulable{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)"}[5m])
             == 1
           for: 30m
           labels:


### PR DESCRIPTION
This allows us to exclude specific namespaces which are included through regex patterns in `alerts.includeNamespaces`, for example when customers install and manage an OpenShift 4 component themselves.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
