### PR TITLE
Expire silences after one day instead of one year

### DIFF
--- a/component/scripts/silence.sh
+++ b/component/scripts/silence.sh
@@ -9,7 +9,7 @@ while IFS= read -r silence; do
   body=$(printf %s "$silence" | \
     jq \
       --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
-      --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
+      --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 day')" \
       --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
       '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
   )

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -534,7 +534,7 @@ default::
 Contains the list of silences to be applied.
 The key is used as the comment of the silence and the value is a dictionary which is passed to Alertmanager.
 
-Silences removed from the hierarchy stay active in Alertmanager for up to a year until they expire.
+Silences removed from the hierarchy stay active in Alertmanager for up to 24h until they expire.
 
 Silences all non-SYN alerts by default.
 

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -12,7 +12,7 @@ data:
       body=$(printf %s "$silence" | \
         jq \
           --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
-          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
+          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 day')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -12,7 +12,7 @@ data:
       body=$(printf %s "$silence" | \
         jq \
           --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
-          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
+          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 day')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -12,7 +12,7 @@ data:
       body=$(printf %s "$silence" | \
         jq \
           --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
-          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
+          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 day')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -12,7 +12,7 @@ data:
       body=$(printf %s "$silence" | \
         jq \
           --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
-          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
+          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 day')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )

--- a/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -12,7 +12,7 @@ data:
       body=$(printf %s "$silence" | \
         jq \
           --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
-          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
+          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 day')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )

--- a/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -12,7 +12,7 @@ data:
       body=$(printf %s "$silence" | \
         jq \
           --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
-          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
+          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 day')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )

--- a/tests/golden/release-4.14/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/release-4.14/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -12,7 +12,7 @@ data:
       body=$(printf %s "$silence" | \
         jq \
           --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
-          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
+          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 day')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -12,7 +12,7 @@ data:
       body=$(printf %s "$silence" | \
         jq \
           --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
-          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
+          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 day')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -12,7 +12,7 @@ data:
       body=$(printf %s "$silence" | \
         jq \
           --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
-          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
+          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 day')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -12,7 +12,7 @@ data:
       body=$(printf %s "$silence" | \
         jq \
           --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
-          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
+          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 day')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -12,7 +12,7 @@ data:
       body=$(printf %s "$silence" | \
         jq \
           --arg startsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '-1 min')" \
-          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 year')" \
+          --arg endsAt "$(date -u +'%Y-%m-%dT%H:%M:%S' --date '+1 day')" \
           --arg createdBy "Kubernetes object \`cronjob/silence\` in the monitoring namespace" \
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )


### PR DESCRIPTION
The cronjob renews the silence every 4 hours. I don't see any added benefits in creating silences with 1 year lifetime instead of one day.

However there is one major downside. If the silence functionality is used to suppress certain alerts temporarily, the silence stays active for 1 year after it's removed from the config hierarchy. To enable the alert again it, the silence has to be expired manually on all clusters.

Reducing this to one day is a compromise that allows to remove silences and ensure they're active again in a reasonable timeframe without having to manually  expire all silences. Happy to discuss other values for the duration.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
