### PR TITLE
Only use auto-discovery Alertmanager config when the feature is enabled

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -112,7 +112,15 @@ local customRules =
       namespace: ns,
     },
     stringData: {
-      'alertmanager.yaml': if params.alertManagerAutoDiscovery.enabled then std.manifestYamlDoc(alertDiscovery.alertmanagerConfig) else alertDiscovery.alertmanagerConfig,
+      'alertmanager.yaml': std.manifestYamlDoc(
+        if params.alertManagerAutoDiscovery.enabled then
+          alertDiscovery.alertmanagerConfig
+        else
+          // We prune the user-provided config in the alert-discovery
+          // implementation. To avoid surprises, we explicitly prune the
+          // user-provided config here, if discovery is disabled.
+          std.prune(params.alertManagerConfig)
+      ),
     },
   },
   [if params.alertManagerAutoDiscovery.enabled && params.alertManagerAutoDiscovery.debug_config_map then '99_discovery_debug_cm']: alertDiscovery.debugConfigMap,


### PR DESCRIPTION


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
