### PR TITLE
Fix OVNKubernetes alert rules for OpenShift 4.14

### DIFF
--- a/class/openshift4-monitoring.yml
+++ b/class/openshift4-monitoring.yml
@@ -47,9 +47,15 @@ parameters:
           control_plane: https://raw.githubusercontent.com/openshift/cluster-network-operator/${openshift4_monitoring:manifests_version}/bindata/network/ovn-kubernetes/self-hosted/alert-rules-control-plane.yaml
         release-4.14:
           common: https://raw.githubusercontent.com/openshift/cluster-network-operator/${openshift4_monitoring:manifests_version}/bindata/network/ovn-kubernetes/common/alert-rules.yaml
-          # We use the "self-hosted" variant of the control-plane alerts, so
-          # we don't have to worry about unresolved gotemplate references.
-          control_plane: https://raw.githubusercontent.com/openshift/cluster-network-operator/release-4.13/bindata/network/ovn-kubernetes/self-hosted/alert-rules-control-plane.yaml
+          # We handle the gotemplate stuff in Jsonnet for now, since Jinja
+          # can't deal with gotemplate expressions like `{{.OvnkubeMasterReplicas}}`.
+          # The only templates that are in the alerting rules can be handled
+          # with a simple string replace.
+          # By default we use the `multi-zone-interconnect` rules for 4.14,
+          # since those rules match the rules that are deployed by default
+          # when selecting OVNKubernetes as the network plugin during
+          # installation.
+          control_plane: https://raw.githubusercontent.com/openshift/cluster-network-operator/release-4.14/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/alert-rules-control-plane.yaml
 
   kapitan:
     dependencies:


### PR DESCRIPTION
OpenShift 4.14 moved the OVNKubernetes control plane alerts (and we can't use the 4.13 alerts, because 4.14 makes significant changes to the OVNKubernetes architecture). Additionally 4.14 introduced gotemplate snippets in the OVNKubernetes alerts that we need to render.

Since the files also contain gotemplate snippets which aren't valid Jinja2, we implement very simple rendering logic which uses `std.strReplace()` in the component.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
