### PR TITLE
Prune cluster-monitoring-config contents

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -82,14 +82,16 @@ local cronjobs = import 'cronjobs.libsonnet';
       },
       data: {
         'config.yaml': std.manifestYamlDoc(
-          {
-            enableUserWorkload: params.enableUserWorkload,
-          } + std.mapWithKey(
-            function(field, value) params.defaultConfig + com.makeMergeable(value),
-            params.configs {
-              prometheusK8s: patchRemoteWrite(super.prometheusK8s, params.remoteWriteDefaults.cluster),
-            }
-          ),
+          std.prune(
+            {
+              enableUserWorkload: params.enableUserWorkload,
+            } + std.mapWithKey(
+              function(field, value) params.defaultConfig + com.makeMergeable(value),
+              params.configs {
+                prometheusK8s: patchRemoteWrite(super.prometheusK8s, params.remoteWriteDefaults.cluster),
+              }
+            ),
+          )
         ),
       },
     },

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -107,6 +107,8 @@ alertmanagerMain:
 
 A dictionary holding the configurations for the https://docs.openshift.com/container-platform/latest/monitoring/configuring-the-monitoring-stack.html#configuring-the-monitoring-stack_configuring-the-monitoring-stack[monitoring components].
 
+The component will remove empty fields (`null`, and empty lists or objects) from the provided configuration.
+
 See the https://docs.openshift.com/container-platform/latest/monitoring/cluster_monitoring/configuring-the-monitoring-stack.html[OpenShift docs] for available parameters.
 
 This table shows the monitoring components you can configure and the keys used to specify the components:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -30,7 +30,6 @@ data:
         "tenant_name": "Test Tenant 1234"
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -30,7 +30,6 @@ data:
         "tenant_name": "Test Tenant 1234"
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -30,7 +30,6 @@ data:
         "tenant_name": "Test Tenant 1234"
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/release-4.11/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -30,7 +30,6 @@ data:
         "tenant_name": "Test Tenant 1234"
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/release-4.12/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -30,7 +30,6 @@ data:
         "tenant_name": "Test Tenant 1234"
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -30,7 +30,6 @@ data:
         "tenant_name": "Test Tenant 1234"
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/release-4.14/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/release-4.14/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -30,7 +30,6 @@ data:
         "tenant_name": "Test Tenant 1234"
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -30,7 +30,6 @@ data:
         "tenant_name": "Test Tenant 1234"
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -30,7 +30,6 @@ data:
         "tenant_name": "Test Tenant 1234"
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -30,7 +30,6 @@ data:
         "tenant_name": "Test Tenant 1234"
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-      "remoteWrite": []
       "retention": "8d"
       "volumeClaimTemplate":
         "spec":


### PR DESCRIPTION
This allows us to remove configurations from the cluster-monitoring-config in the hierarchy.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
