### PR TITLE
Add support for deploying an additional node-exporter DaemonSet

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/projectsyn/commodore-component-template.git",
-  "commit": "ea12efff947bce80cf31a3f1ed4412eab40e8b33",
+  "commit": "26ee71e475cca036551c68a6c6b2285fe86139a0",
   "checkout": "main",
   "context": {
     "cookiecutter": {
@@ -16,8 +16,8 @@
       "automerge_patch": "y",
       "automerge_patch_v0": "n",
       "automerge_patch_regexp_blocklist": "",
-      "automerge_patch_v0_regexp_allowlist": "",
-      "automerge_minor_regexp_allowlist": "",
+      "automerge_patch_v0_regexp_allowlist": "^quay.io/brancz/kube-rbac-proxy$",
+      "automerge_minor_regexp_allowlist": "^quay.io/appuio/oc$;^quay.io/brancz/kube-rbac-proxy$;^quay.io/prometheus/node-exporter$",
       "auto_release": "y",
       "copyright_holder": "VSHN AG <info@vshn.ch>",
       "copyright_year": "2021",

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -235,7 +235,14 @@ parameters:
       oc:
         image: quay.io/appuio/oc
         tag: v4.14
-
+      node_exporter:
+        registry: quay.io
+        repository: prometheus/node-exporter
+        tag: v1.8.1
+      kube_rbac_proxy:
+        registry: quay.io
+        repository: brancz/kube-rbac-proxy
+        tag: v0.18.0
 
     capacityAlerts:
       enabled: true
@@ -402,3 +409,15 @@ parameters:
     secrets: {}
 
     cronjobs: {}
+
+    customNodeExporter:
+      enabled: false
+      collectors:
+        - network_route
+      args: []
+      metricRelabelings:
+        # only keep routes for host interfaces (assumes that host interfaces
+        # are `ensX` which should hold on RHCOS)
+        - action: keep
+          sourceLabels: ['__name__', 'device']
+          regex: 'node_network_route.*;ens.*'

--- a/component/custom-node-exporter.libsonnet
+++ b/component/custom-node-exporter.libsonnet
@@ -1,0 +1,208 @@
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local nodeExporter = import 'github.com/openshift/cluster-monitoring-operator/jsonnet/components/node-exporter.libsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_monitoring;
+
+// Disable all collectors by default. Note that this list may need to be
+// updated manually if a new node-exporter release introduces additional
+// collectors.
+local neDefaultArgs = [
+  '--no-collector.arp',
+  '--no-collector.bcache',
+  '--no-collector.bonding',
+  '--no-collector.btrfs',
+  '--no-collector.buddyinfo',
+  '--no-collector.cgroups',
+  '--no-collector.conntrack',
+  '--no-collector.cpu',
+  '--no-collector.cpufreq',
+  '--no-collector.diskstats',
+  '--no-collector.dmi',
+  '--no-collector.drbd',
+  '--no-collector.drm',
+  '--no-collector.edac',
+  '--no-collector.entropy',
+  '--no-collector.ethtool',
+  '--no-collector.fibrechannel',
+  '--no-collector.filefd',
+  '--no-collector.filesystem',
+  '--no-collector.hwmon',
+  '--no-collector.infiniband',
+  '--no-collector.interrupts',
+  '--no-collector.ipvs',
+  '--no-collector.ksmd',
+  '--no-collector.lnstat',
+  '--no-collector.loadavg',
+  '--no-collector.logind',
+  '--no-collector.mdadm',
+  '--no-collector.meminfo',
+  '--no-collector.meminfo_numa',
+  '--no-collector.mountstats',
+  '--no-collector.netclass',
+  '--no-collector.netdev',
+  '--no-collector.netstat',
+  '--no-collector.network_route',
+  '--no-collector.nfs',
+  '--no-collector.nfsd',
+  '--no-collector.ntp',
+  '--no-collector.nvme',
+  '--no-collector.os',
+  '--no-collector.perf',
+  '--no-collector.powersupplyclass',
+  '--no-collector.pressure',
+  '--no-collector.processes',
+  '--no-collector.rapl',
+  '--no-collector.schedstat',
+  '--no-collector.selinux',
+  '--no-collector.slabinfo',
+  '--no-collector.sockstat',
+  '--no-collector.softirqs',
+  '--no-collector.softnet',
+  '--no-collector.stat',
+  '--no-collector.supervisord',
+  '--no-collector.sysctl',
+  '--no-collector.systemd',
+  '--no-collector.tapestats',
+  '--no-collector.tcpstat',
+  '--no-collector.textfile',
+  '--no-collector.thermal_zone',
+  '--no-collector.time',
+  '--no-collector.timex',
+  '--no-collector.udp_queues',
+  '--no-collector.uname',
+  '--no-collector.vmstat',
+  '--no-collector.watchdog',
+  '--no-collector.wifi',
+  '--no-collector.xfs',
+  '--no-collector.zfs',
+  '--no-collector.zoneinfo',
+];
+
+local containsStr(pat, str) = std.length(std.findSubstr(pat, str)) > 0;
+
+local enabledCollectors =
+  com.renderArray(params.customNodeExporter.collectors);
+
+local skipDefaultArg(a) = std.foldl(
+  function(skip, c) skip || containsStr(c, a),
+  enabledCollectors,
+  false
+);
+
+// generate command line args to enable collectors that are requested
+local neCollectorArgs = [
+  '--collector.%s' % c
+  for c in enabledCollectors
+];
+
+local config = {
+  commonLabels: {
+    'app.kubernetes.io/part-of': 'openshift4-monitoring',
+  },
+  name: 'appuio-node-exporter',
+  namespace: params.namespace,
+  version: params.images.node_exporter.tag,
+  port: 9199,
+  image: '%(registry)s/%(repository)s:%(tag)s' % params.images.node_exporter,
+  kubeRbacProxyImage: '%(registry)s/%(repository)s:%(tag)s' % params.images.kube_rbac_proxy,
+  ignoredNetworkDevices:: '^.*$',
+};
+
+local ne = nodeExporter(config) {
+  // customize node-exporter args. We disable all collectors by default, and
+  // only enable the ones requested via component parameters.
+  daemonset+: {
+    spec+: {
+      template+: {
+        spec+: {
+          containers: std.map(
+            function(c)
+              if c.name == 'appuio-node-exporter' then
+                c {
+                  args: [
+                    a
+                    for a in c.args
+                    if !containsStr('collector', a)
+                  ] + [
+                    // only add the disable args for collectors that the user
+                    // hasn't requested, since node-exporter doesn't support
+                    // passing a disable and enable flag for the same collector.
+                    a
+                    for a in neDefaultArgs
+                    if !skipDefaultArg(a)
+                  ] + neCollectorArgs + params.customNodeExporter.args,
+                  // fixup `date` call to use busybox compatible option
+                  command: std.map(
+                    function(cmd)
+                      std.strReplace(cmd, '--iso-8601=seconds', '-Iseconds'),
+                    c.command
+                  ),
+                }
+              else
+                c,
+            super.containers
+          ),
+          // Fixup service-ca issued certificate secret name
+          volumes: std.map(
+            function(v) if v.name == 'node-exporter-tls' then
+              v {
+                secret: {
+                  secretName: 'appuio-node-exporter-tls',
+                },
+              }
+            else
+              v,
+            super.volumes
+          ),
+        },
+      },
+    },
+  },
+  // Fixup the secret name to use for the service-ca issued cert
+  service+: {
+    metadata+: {
+      annotations+: {
+        'service.beta.openshift.io/serving-cert-secret-name': 'appuio-node-exporter-tls',
+      },
+    },
+  },
+  // patch the service monitor to validate the TLS certificate and configure
+  // user-provided custom metricRelabelings.
+  serviceMonitor+: {
+    spec+: {
+      endpoints: std.map(
+        function(ep) ep {
+          metricRelabelings: params.customNodeExporter.metricRelabelings,
+          tlsConfig: {
+            ca: {},
+            caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
+            cert: {},
+            certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
+            keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
+            serverName: 'appuio-node-exporter.openshift-monitoring.svc',
+          },
+        },
+        super.endpoints
+      ),
+    },
+  },
+
+  // we don't need the networkpolicy
+  networkPolicy:: {},
+  // we don't need the servicemonitor generated by
+  // openshift-cluster-monitoring, we customize the one generated
+  // by the kube-prometheus Jsonnet.
+  minimalServiceMonitor:: {},
+  // we don't need a copy of the SCC for our node-exporter, we can use the one
+  // generated by the cluster-monitoring-operator.
+  securityContextConstraints:: {},
+  // we don't need the default node-exporter prometheus rules
+  mixin:: {},
+  prometheusRule:: {},
+};
+
+std.objectValues(ne)

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -137,4 +137,7 @@ local cronjobs = import 'cronjobs.libsonnet';
   [if params.capacityAlerts.enabled then 'capacity_rules']: capacity.rules,
   [if std.length(customRules.spec.groups) > 0 then 'custom_rules']: customRules,
   [if std.length(cronjobs.cronjobs) > 0 then 'cronjobs']: cronjobs.cronjobs,
+  // TODO: enable flag
+  [if params.customNodeExporter.enabled then 'appuio_node_exporter']:
+    (import 'custom-node-exporter.libsonnet'),
 }

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -812,3 +812,59 @@ cronjobs:
       spec:
         failedJobsHistoryLimit: 1
 ----
+
+== `customNodeExporter`
+
+This parameter allows users to deploy an additional node-exporter DaemonSet.
+We provide this option, since OpenShift's cluster-monitoring stack currently doesn't allow users to customize the bundled node-exporter DaemonSet.
+
+Currently, the parameter is tailored to allow users to run an additional node-exporter which enables collectors that aren't enabled in the default node exporter.
+
+The configuration is rendered by using the same Jsonnet that's used by the OpenShift cluster-monitoring stack to generate the default node-exporter DaemonSet.
+The component further customizes the resulting manifests to ensure that there's no conflicts between the default node-exporter and the additional node-exporter.
+
+The additional node-exporter is deployed in the namespace indicated by parameter `namespace`.
+By default this is namespace `openshift-monitoring`.
+The component also deploys a `ServiceMonitor` which ensures that the additional node-exporter is scraped by the cluster-monitoring stack's Prometheus.
+
+Users can configure arbitrary recording and alerting rules which use metrics scraped from the additional node-exporter via parameter `rules`.
+
+=== `enabled`
+
+[horizontal]
+type:: bool
+default:: `false`
+
+Whether to deploy the additional node-exporter.
+
+=== `collectors`
+
+[horizontal]
+type:: list
+default:: `["network_route"]`
+
+Which collectors to enable in the additional node-exporter.
+By default, all collectors are disabled.
+Users can remove entries from this list by providing an existing entry prefixed with `~`.
+
+=== `args`
+[horizontal]
+type:: list
+default:: `[]`
+
+
+Additional command line arguments to pass to the additional node-exporter.
+Please note that specifying `--[no-]collector.<name>` here will break the DaemonSet, since `node-exporter` doesn't support specifying these flags multiple times.
+Users should use parameter `customNodeExporter.collectors` to enable collectors.
+
+=== `metricRelabelings`
+
+[horizontal]
+type:: list
+default:: https://github.com/appuio/component-openshift4-monitoring/blob/master/class/defaults.yml[See `class/defaults.yml`]
+
+This parameter allows users to specify the content of field `metricRelabelings` of the `ServiceMonitor` which is created for the additional node-exporter.
+By default, the component drops all metrics except `node_network_route*` metrics for host devices prefixed with `ens`.
+Since this component only applies to OpenShift 4, we know that any node's host interfaces will use device names that are prefixed with `ens`.
+
+Users are encouraged to extend or overwrite this parameter to ensure all the metrics they're interested in are actually scraped by Prometheus.

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,39 @@
         "automerge",
         "bump:patch"
       ]
+    },
+    {
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "matchCurrentVersion": "/^v?0\\./",
+      "automerge": true,
+      "platformAutomerge": false,
+      "labels": [
+        "dependency",
+        "automerge",
+        "bump:patch"
+      ],
+      "matchPackagePatterns": [
+        "^quay.io/brancz/kube-rbac-proxy$"
+      ]
+    },
+    {
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "automerge": true,
+      "platformAutomerge": false,
+      "labels": [
+        "dependency",
+        "automerge",
+        "bump:minor"
+      ],
+      "matchPackagePatterns": [
+        "^quay.io/appuio/oc$",
+        "^quay.io/brancz/kube-rbac-proxy$",
+        "^quay.io/prometheus/node-exporter$"
+      ]
     }
   ]
 }

--- a/tests/custom-rules.yml
+++ b/tests/custom-rules.yml
@@ -13,6 +13,9 @@ parameters:
   openshift4_monitoring:
     manifests_version: release-4.13
 
+    customNodeExporter:
+      enabled: true
+
     alerts:
       excludeNamespaces:
         - openshift-adp

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/appuio_node_exporter.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/appuio_node_exporter.yaml
@@ -1,0 +1,369 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift4-monitoring
+  name: appuio-node-exporter
+  namespace: openshift-monitoring
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - node-exporter
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift4-monitoring
+  name: appuio-node-exporter
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio-node-exporter
+subjects:
+  - kind: ServiceAccount
+    name: appuio-node-exporter
+    namespace: openshift-monitoring
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/part-of: openshift4-monitoring
+  name: appuio-node-exporter
+  namespace: openshift-monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: openshift4-monitoring
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: appuio-node-exporter
+      labels:
+        app.kubernetes.io/managed-by: cluster-monitoring-operator
+        app.kubernetes.io/part-of: openshift4-monitoring
+    spec:
+      automountServiceAccountToken: true
+      containers:
+        - args:
+            - --web.listen-address=127.0.0.1:9199
+            - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
+            - --path.udev.data=/host/root/run/udev/data
+            - --no-collector.arp
+            - --no-collector.bcache
+            - --no-collector.bonding
+            - --no-collector.btrfs
+            - --no-collector.buddyinfo
+            - --no-collector.cgroups
+            - --no-collector.conntrack
+            - --no-collector.cpu
+            - --no-collector.cpufreq
+            - --no-collector.diskstats
+            - --no-collector.dmi
+            - --no-collector.drbd
+            - --no-collector.drm
+            - --no-collector.edac
+            - --no-collector.entropy
+            - --no-collector.ethtool
+            - --no-collector.fibrechannel
+            - --no-collector.filefd
+            - --no-collector.filesystem
+            - --no-collector.hwmon
+            - --no-collector.infiniband
+            - --no-collector.interrupts
+            - --no-collector.ipvs
+            - --no-collector.ksmd
+            - --no-collector.lnstat
+            - --no-collector.loadavg
+            - --no-collector.logind
+            - --no-collector.mdadm
+            - --no-collector.meminfo
+            - --no-collector.meminfo_numa
+            - --no-collector.mountstats
+            - --no-collector.netclass
+            - --no-collector.netdev
+            - --no-collector.netstat
+            - --no-collector.nfs
+            - --no-collector.nfsd
+            - --no-collector.ntp
+            - --no-collector.nvme
+            - --no-collector.os
+            - --no-collector.perf
+            - --no-collector.powersupplyclass
+            - --no-collector.pressure
+            - --no-collector.processes
+            - --no-collector.rapl
+            - --no-collector.schedstat
+            - --no-collector.selinux
+            - --no-collector.slabinfo
+            - --no-collector.sockstat
+            - --no-collector.softirqs
+            - --no-collector.softnet
+            - --no-collector.stat
+            - --no-collector.supervisord
+            - --no-collector.sysctl
+            - --no-collector.systemd
+            - --no-collector.tapestats
+            - --no-collector.tcpstat
+            - --no-collector.textfile
+            - --no-collector.thermal_zone
+            - --no-collector.time
+            - --no-collector.timex
+            - --no-collector.udp_queues
+            - --no-collector.uname
+            - --no-collector.vmstat
+            - --no-collector.watchdog
+            - --no-collector.wifi
+            - --no-collector.xfs
+            - --no-collector.zfs
+            - --no-collector.zoneinfo
+            - --collector.network_route
+          command:
+            - /bin/sh
+            - -c
+            - |
+              export GOMAXPROCS=4
+              # We don't take CPU affinity into account as the container doesn't have integer CPU requests.
+              # In case of error, fallback to the default value.
+              NUM_CPUS=$(grep -c '^processor' "/proc/cpuinfo" 2>/dev/null || echo "0")
+              if [ "$NUM_CPUS" -lt "$GOMAXPROCS" ]; then
+                export GOMAXPROCS="$NUM_CPUS"
+              fi
+              echo "ts=$(date -Iseconds) num_cpus=$NUM_CPUS gomaxprocs=$GOMAXPROCS"
+              exec /bin/node_exporter "$0" "$@"
+          image: quay.io/prometheus/node-exporter:v1.8.1
+          name: appuio-node-exporter
+          resources:
+            limits:
+              cpu: 250m
+              memory: 180Mi
+            requests:
+              cpu: 8m
+              memory: 32Mi
+          securityContext: {}
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /host/sys
+              mountPropagation: HostToContainer
+              name: sys
+              readOnly: true
+            - mountPath: /host/root
+              mountPropagation: HostToContainer
+              name: root
+              readOnly: true
+            - mountPath: /var/node_exporter/textfile
+              name: node-exporter-textfile
+              readOnly: true
+          workingDir: /var/node_exporter/textfile
+        - args:
+            - --logtostderr
+            - --secure-listen-address=[$(IP)]:9199
+            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+            - --upstream=http://127.0.0.1:9199/
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --client-ca-file=/etc/tls/client/client-ca.crt
+            - --config-file=/etc/kube-rbac-policy/config.yaml
+          env:
+            - name: IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          image: quay.io/brancz/kube-rbac-proxy:v0.18.0
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: 9199
+              hostPort: 9199
+              name: https
+          resources:
+            requests:
+              cpu: 1m
+              memory: 15Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: node-exporter-tls
+              readOnly: false
+            - mountPath: /etc/tls/client
+              name: metrics-client-ca
+              readOnly: false
+            - mountPath: /etc/kube-rbac-policy
+              name: node-exporter-kube-rbac-proxy-config
+              readOnly: true
+      hostNetwork: true
+      hostPID: true
+      initContainers:
+        - command:
+            - /bin/sh
+            - -c
+            - '[[ ! -d /node_exporter/collectors/init ]] || find /node_exporter/collectors/init
+              -perm /111 -type f -exec {} \;'
+          env:
+            - name: TMPDIR
+              value: /tmp
+          image: quay.io/prometheus/node-exporter:v1.8.1
+          name: init-textfile
+          resources:
+            requests:
+              cpu: 1m
+              memory: 1Mi
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /var/node_exporter/textfile
+              name: node-exporter-textfile
+              readOnly: false
+            - mountPath: /var/log/wtmp
+              name: node-exporter-wtmp
+              readOnly: true
+          workingDir: /var/node_exporter/textfile
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      securityContext: {}
+      serviceAccountName: appuio-node-exporter
+      tolerations:
+        - operator: Exists
+      volumes:
+        - hostPath:
+            path: /sys
+          name: sys
+        - hostPath:
+            path: /
+          name: root
+        - emptyDir: {}
+          name: node-exporter-textfile
+        - name: node-exporter-tls
+          secret:
+            secretName: appuio-node-exporter-tls
+        - hostPath:
+            path: /var/log/wtmp
+            type: File
+          name: node-exporter-wtmp
+        - configMap:
+            name: metrics-client-ca
+          name: metrics-client-ca
+        - name: node-exporter-kube-rbac-proxy-config
+          secret:
+            secretName: node-exporter-kube-rbac-proxy-config
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+---
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift4-monitoring
+  name: node-exporter-kube-rbac-proxy-config
+  namespace: openshift-monitoring
+stringData:
+  config.yaml: |-
+    "authorization":
+      "static":
+      - "path": "/metrics"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
+        "verb": "get"
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: appuio-node-exporter-tls
+  labels:
+    app.kubernetes.io/part-of: openshift4-monitoring
+  name: appuio-node-exporter
+  namespace: openshift-monitoring
+spec:
+  clusterIP: None
+  ports:
+    - name: https
+      port: 9199
+      targetPort: https
+  selector:
+    app.kubernetes.io/part-of: openshift4-monitoring
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift4-monitoring
+  name: appuio-node-exporter
+  namespace: openshift-monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift4-monitoring
+    monitoring.openshift.io/collection-profile: full
+  name: appuio-node-exporter
+  namespace: openshift-monitoring
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 15s
+      metricRelabelings:
+        - action: keep
+          regex: node_network_route.*;ens.*
+          sourceLabels:
+            - __name__
+            - device
+      port: https
+      relabelings:
+        - action: replace
+          regex: (.*)
+          replacement: $1
+          sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: instance
+      scheme: https
+      tlsConfig:
+        ca: {}
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        cert: {}
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+        serverName: appuio-node-exporter.openshift-monitoring.svc
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: openshift4-monitoring


### PR DESCRIPTION
We reuse the cluster-monitoring-operator node-exporter Jsonnet to generate the DaemonSet and associated resources, and patch the output to adjust the node-exporter to not conflict with the default node-exporter and to remove resources that we don't need.

Additionally, we enable automerge for the 3rd party container images used by the component.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
