### PR TITLE
Tune `NodeMemoryMajorPageFaults` alert

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -206,6 +206,9 @@ parameters:
           PrometheusRemoteWriteDesiredShards:
             annotations:
               runbook_url: https://hub.syn.tools/openshift4-monitoring/runbooks/remotewrite.html
+          NodeMemoryMajorPagesFaults:
+            # Only alert for >100*cores major page faults/node instead of >500/node
+            expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > on (instance) (count by (instance) (node_cpu_info{}) * 100)
         release-4.13: {}
         release-4.14: {}
       # Alerts to ignore for user workload monitoring

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1523,8 +1523,8 @@ spec:
               Please check that there is enough memory available at this instance.
             summary: Memory major page faults are occurring at very high rate.
             syn_component: openshift4-monitoring
-          expr: |
-            rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > 500
+          expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > on (instance)
+            (count by (instance) (node_cpu_info{}) * 100)
           for: 15m
           labels:
             severity: warning
@@ -1895,6 +1895,20 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             avg_over_time(prometheus_engine_queries{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) / max_over_time(prometheus_engine_queries_concurrent_max{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0.8
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusKubernetesListWatchFailures
+          annotations:
+            description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
+              is experiencing {{ printf "%.0f" $value }} failures with LIST/WATCH
+              requests to the Kubernetes API in the last 5 minutes.
+            summary: Requests in Kubernetes SD are failing.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_sd_kubernetes_failures_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
           for: 15m
           labels:
             severity: warning

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1523,8 +1523,8 @@ spec:
               Please check that there is enough memory available at this instance.
             summary: Memory major page faults are occurring at very high rate.
             syn_component: openshift4-monitoring
-          expr: |
-            rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > 500
+          expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > on (instance)
+            (count by (instance) (node_cpu_info{}) * 100)
           for: 15m
           labels:
             severity: warning
@@ -1895,6 +1895,20 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             avg_over_time(prometheus_engine_queries{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) / max_over_time(prometheus_engine_queries_concurrent_max{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0.8
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusKubernetesListWatchFailures
+          annotations:
+            description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
+              is experiencing {{ printf "%.0f" $value }} failures with LIST/WATCH
+              requests to the Kubernetes API in the last 5 minutes.
+            summary: Requests in Kubernetes SD are failing.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_sd_kubernetes_failures_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
           for: 15m
           labels:
             severity: warning

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1525,8 +1525,8 @@ spec:
               Please check that there is enough memory available at this instance.
             summary: Memory major page faults are occurring at very high rate.
             syn_component: openshift4-monitoring
-          expr: |
-            rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > 500
+          expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > on (instance)
+            (count by (instance) (node_cpu_info{}) * 100)
           for: 15m
           labels:
             severity: warning
@@ -1897,6 +1897,20 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             avg_over_time(prometheus_engine_queries{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) / max_over_time(prometheus_engine_queries_concurrent_max{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0.8
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusKubernetesListWatchFailures
+          annotations:
+            description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
+              is experiencing {{ printf "%.0f" $value }} failures with LIST/WATCH
+              requests to the Kubernetes API in the last 5 minutes.
+            summary: Requests in Kubernetes SD are failing.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_sd_kubernetes_failures_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
           for: 15m
           labels:
             severity: warning

--- a/tests/golden/ovn-kubernetes/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/ovn-kubernetes/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1657,8 +1657,8 @@ spec:
               Please check that there is enough memory available at this instance.
             summary: Memory major page faults are occurring at very high rate.
             syn_component: openshift4-monitoring
-          expr: |
-            rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > 500
+          expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > on (instance)
+            (count by (instance) (node_cpu_info{}) * 100)
           for: 15m
           labels:
             severity: warning
@@ -2029,6 +2029,20 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             avg_over_time(prometheus_engine_queries{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) / max_over_time(prometheus_engine_queries_concurrent_max{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0.8
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusKubernetesListWatchFailures
+          annotations:
+            description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
+              is experiencing {{ printf "%.0f" $value }} failures with LIST/WATCH
+              requests to the Kubernetes API in the last 5 minutes.
+            summary: Requests in Kubernetes SD are failing.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_sd_kubernetes_failures_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
           for: 15m
           labels:
             severity: warning

--- a/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/release-4.13/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1522,8 +1522,8 @@ spec:
               Please check that there is enough memory available at this instance.
             summary: Memory major page faults are occurring at very high rate.
             syn_component: openshift4-monitoring
-          expr: |
-            rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > 500
+          expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > on (instance)
+            (count by (instance) (node_cpu_info{}) * 100)
           for: 15m
           labels:
             severity: warning
@@ -1894,6 +1894,20 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             avg_over_time(prometheus_engine_queries{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) / max_over_time(prometheus_engine_queries_concurrent_max{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0.8
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusKubernetesListWatchFailures
+          annotations:
+            description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
+              is experiencing {{ printf "%.0f" $value }} failures with LIST/WATCH
+              requests to the Kubernetes API in the last 5 minutes.
+            summary: Requests in Kubernetes SD are failing.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_sd_kubernetes_failures_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
           for: 15m
           labels:
             severity: warning

--- a/tests/golden/release-4.14/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/release-4.14/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1523,8 +1523,8 @@ spec:
               Please check that there is enough memory available at this instance.
             summary: Memory major page faults are occurring at very high rate.
             syn_component: openshift4-monitoring
-          expr: |
-            rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > 500
+          expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > on (instance)
+            (count by (instance) (node_cpu_info{}) * 100)
           for: 15m
           labels:
             severity: warning
@@ -1895,6 +1895,20 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             avg_over_time(prometheus_engine_queries{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) / max_over_time(prometheus_engine_queries_concurrent_max{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0.8
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusKubernetesListWatchFailures
+          annotations:
+            description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
+              is experiencing {{ printf "%.0f" $value }} failures with LIST/WATCH
+              requests to the Kubernetes API in the last 5 minutes.
+            summary: Requests in Kubernetes SD are failing.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_sd_kubernetes_failures_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
           for: 15m
           labels:
             severity: warning

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1523,8 +1523,8 @@ spec:
               Please check that there is enough memory available at this instance.
             summary: Memory major page faults are occurring at very high rate.
             syn_component: openshift4-monitoring
-          expr: |
-            rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > 500
+          expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > on (instance)
+            (count by (instance) (node_cpu_info{}) * 100)
           for: 15m
           labels:
             severity: warning
@@ -1895,6 +1895,20 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             avg_over_time(prometheus_engine_queries{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) / max_over_time(prometheus_engine_queries_concurrent_max{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0.8
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusKubernetesListWatchFailures
+          annotations:
+            description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
+              is experiencing {{ printf "%.0f" $value }} failures with LIST/WATCH
+              requests to the Kubernetes API in the last 5 minutes.
+            summary: Requests in Kubernetes SD are failing.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_sd_kubernetes_failures_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
           for: 15m
           labels:
             severity: warning

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1605,8 +1605,8 @@ spec:
               Please check that there is enough memory available at this instance.
             summary: Memory major page faults are occurring at very high rate.
             syn_component: openshift4-monitoring
-          expr: |
-            rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > 500
+          expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > on (instance)
+            (count by (instance) (node_cpu_info{}) * 100)
           for: 15m
           labels:
             severity: warning
@@ -1999,6 +1999,21 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             avg_over_time(prometheus_engine_queries{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) / max_over_time(prometheus_engine_queries_concurrent_max{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0.8
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+            syn_team: clumsy-donkeys
+        - alert: SYN_PrometheusKubernetesListWatchFailures
+          annotations:
+            description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
+              is experiencing {{ printf "%.0f" $value }} failures with LIST/WATCH
+              requests to the Kubernetes API in the last 5 minutes.
+            summary: Requests in Kubernetes SD are failing.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_sd_kubernetes_failures_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
           for: 15m
           labels:
             severity: warning

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1523,8 +1523,8 @@ spec:
               Please check that there is enough memory available at this instance.
             summary: Memory major page faults are occurring at very high rate.
             syn_component: openshift4-monitoring
-          expr: |
-            rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > 500
+          expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > on (instance)
+            (count by (instance) (node_cpu_info{}) * 100)
           for: 15m
           labels:
             severity: warning
@@ -1895,6 +1895,20 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             avg_over_time(prometheus_engine_queries{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) / max_over_time(prometheus_engine_queries_concurrent_max{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0.8
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusKubernetesListWatchFailures
+          annotations:
+            description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
+              is experiencing {{ printf "%.0f" $value }} failures with LIST/WATCH
+              requests to the Kubernetes API in the last 5 minutes.
+            summary: Requests in Kubernetes SD are failing.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_sd_kubernetes_failures_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
           for: 15m
           labels:
             severity: warning

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1523,8 +1523,8 @@ spec:
               Please check that there is enough memory available at this instance.
             summary: Memory major page faults are occurring at very high rate.
             syn_component: openshift4-monitoring
-          expr: |
-            rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > 500
+          expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m]) > on (instance)
+            (count by (instance) (node_cpu_info{}) * 100)
           for: 15m
           labels:
             severity: warning
@@ -1895,6 +1895,20 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             avg_over_time(prometheus_engine_queries{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) / max_over_time(prometheus_engine_queries_concurrent_max{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0.8
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-monitoring
+        - alert: SYN_PrometheusKubernetesListWatchFailures
+          annotations:
+            description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}}
+              is experiencing {{ printf "%.0f" $value }} failures with LIST/WATCH
+              requests to the Kubernetes API in the last 5 minutes.
+            summary: Requests in Kubernetes SD are failing.
+            syn_component: openshift4-monitoring
+          expr: |
+            increase(prometheus_sd_kubernetes_failures_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
           for: 15m
           labels:
             severity: warning


### PR DESCRIPTION
Adjust the alert to fire when there's >100*cores major page faults on a node instead of >500.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
