### PR TITLE
Make hidden `runbook_url` annotations visible

### DIFF
--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -223,9 +223,18 @@ local patchRules = {
       function(group)
         group {
           rules: std.map(
-            function(rule) alertpatching.patchRule(rule, rulePatches, false) {
-              expr: patchExpr(super.expr),
-            },
+            function(rule)
+              alertpatching.patchRule(rule, rulePatches, false) {
+                // NOTE(sg): Make runbook_url annotation visible so we can
+                // always patch it. This is necessary because some upstream
+                // Jsonnet hides the annotation with `runbook_url::` for
+                // alerts where they don't want to set the annotation.
+                annotations+:
+                  if std.objectHasAll(rule.annotations, 'runbook_url') then {
+                    runbook_url::: super.runbook_url,
+                  } else {},
+                expr: patchExpr(super.expr),
+              } + { annotations: std.prune(super.annotations) },
             group.rules
           ),
         },


### PR DESCRIPTION
Some upstream Jsonnet hides the `runbook_url` annotation on alerts.

Because of that, some of our patches which insert the `runbook_url` annotation don't work correctly with go-jsonnet 0.20.0, which correctly inherits field visibility in object comprehension (e.g. `com.makeMergeable()`). This behavior will also be fixed in an upcoming C++ jsonnet version, cf. https://github.com/google/jsonnet/pull/1140 so we adjust the component to make all `runbook_url` annotations visible.

Notably, the upstream Jsonnet which hides the annotation also sets it to `null`, so we can then clean up the unwanted `runbook_url: null` annotations by calling `std.prune()` on the annotations object.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
