### PR TITLE
Add config section `metricsServer`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -54,6 +54,7 @@ parameters:
       k8sPrometheusAdapter: {}
       openshiftStateMetrics: {}
       thanosQuerier: {}
+      metricsServer: {}
     configsUserWorkload:
       alertmanager:
         enabled: true

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -81,29 +81,7 @@ A parameter to enable https://docs.openshift.com/container-platform/latest/monit
 
 [horizontal]
 type:: dictionary
-default::
-+
-[source,yaml]
-----
-prometheusK8s:
-  remoteWrite: []
-  _remoteWrite: {}
-  externalLabels:
-    cluster_id: ${cluster:name}
-    tenant_id: ${cluster:tenant}
-  retention: 8d
-  volumeClaimTemplate:
-    spec:
-      resources:
-        requests:
-          storage: 50Gi
-alertmanagerMain:
-  volumeClaimTemplate:
-    spec:
-      resources:
-        requests:
-          storage: 2Gi
-----
+default:: https://github.com/appuio/component-openshift4-monitoring/blob/master/class/defaults.yml[See `class/defaults.yml`]
 
 A dictionary holding the configurations for the https://docs.openshift.com/container-platform/latest/monitoring/configuring-the-monitoring-stack.html#configuring-the-monitoring-stack_configuring-the-monitoring-stack[monitoring components].
 
@@ -123,7 +101,8 @@ This table shows the monitoring components you can configure and the keys used t
 |openshift-state-metrics|`openshiftStateMetrics`
 |Grafana|`grafana`
 |Telemeter Client|`telemeterClient`
-|Prometheus Adapter|`k8sPrometheusAdapter`
+|Prometheus Adapter (for OpenShift 4.15 and older)|`k8sPrometheusAdapter`
+|Metrics Server (for OpenShift 4.16 and newer)|`metricsServer`
 |Thanos Querier|`thanosQuerier`
 |====
 

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -19,6 +19,9 @@ data:
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+    "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -19,6 +19,9 @@ data:
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+    "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -19,6 +19,9 @@ data:
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+    "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/ovn-kubernetes/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/ovn-kubernetes/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -19,6 +19,9 @@ data:
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+    "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/release-4.14/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/release-4.14/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -19,6 +19,9 @@ data:
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+    "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/release-4.15/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/release-4.15/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -19,6 +19,9 @@ data:
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+    "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/release-4.16/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/release-4.16/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -19,6 +19,9 @@ data:
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+    "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -19,6 +19,9 @@ data:
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+    "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -19,6 +19,9 @@ data:
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+    "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -19,6 +19,9 @@ data:
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+    "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -19,6 +19,9 @@ data:
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
+    "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""


### PR DESCRIPTION
This ensures that the new metrics-server component of the cluster monitoring stack has the default configs (e.g. node selector) applied.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
