### PR TITLE
Use `syn-teams.libsonnet` for alert routing discovery and alert patching

### DIFF
--- a/jsonnetfile.jsonnet
+++ b/jsonnetfile.jsonnet
@@ -4,6 +4,16 @@
     {
       source: {
         git: {
+          remote: 'https://github.com/projectsyn/jsonnet-libs',
+          subdir: '',
+        },
+      },
+      version: 'main',
+      name: 'syn',
+    },
+    {
+      source: {
+        git: {
           remote: 'https://github.com/openshift/cluster-monitoring-operator',
           subdir: 'jsonnet',
         },

--- a/lib/openshift4-monitoring-alert-patching.libsonnet
+++ b/lib/openshift4-monitoring-alert-patching.libsonnet
@@ -2,7 +2,7 @@
 // arbitrary alert rules to adhere to the format required by the component's
 // approach for allowing us to patch upstream rules.
 local com = import 'lib/commodore.libjsonnet';
-local prom = import 'lib/prom.libsonnet';
+local syn_teams = import 'syn/syn-teams.libsonnet';
 
 local inv = com.inventory();
 
@@ -113,7 +113,7 @@ local patchRule(rule, patches={}, patchName=true) =
       then
         rule.labels.syn_team
       else
-        prom.teamForApplication(inv.parameters._instance);
+        syn_teams.teamForApplication(inv.parameters._instance);
     rule {
       // Change alert names so we don't get multiple alerts with the same
       // name, as the logging operator deploys its own copy of these

--- a/lib/openshift4-monitoring-prom.libsonnet
+++ b/lib/openshift4-monitoring-prom.libsonnet
@@ -4,12 +4,9 @@
  *        API reference: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md
  */
 
-local com = import 'lib/commodore.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 
 local alertpatching = import 'lib/alert-patching.libsonnet';
-
-local inv = com.inventory();
 
 // Define Prometheus Operator API versions
 local api_version = {
@@ -56,81 +53,6 @@ local prometheusRule(name) =
   */
   Alertmanager(name):
     kube._Object(api_version.monitoring, 'Alertmanager', name),
-
-  /**
-  * \brief Returns an array with the (aliased) application name and if aliased the original name in the second position.
-  *
-  * The application name is translated from kebab-case to snake_case, except if the second parameter is set to true.
-  *
-  * \arg name
-  *    The application name. Can be `name` or `name as alias`.
-  * \arg raw
-  *    If set to true, the application name is not translated from kebab-case to snake_case.
-  * \return
-  *    An array with the (aliased) application name and if aliased the original name in the second position.
-  */
-  appKeys: function(name, raw=false)
-    local normalized = function(name) if raw then name else std.strReplace(name, '-', '_');
-    // can be simplified with jsonnet > 0.19 which would support ' as ' as the substring
-    local parts = std.split(name, ' ');
-    if std.length(parts) == 1 then
-      [ normalized(parts[0]) ]
-    else if std.length(parts) == 3 && parts[1] == 'as' then
-      [ normalized(parts[2]), normalized(parts[0]) ]
-    else
-      error 'invalid application name `%s`' % name,
-
-  /**
-  * \brief Returns the team for the given application or null.
-  *
-  * It does so by looking at the top level syn parameter.
-  * The syn parameter should look roughly like this.
-  *
-  *   syn:
-  *     owner: clumsy-donkeys
-  *     teams:
-  *       chubby-cockroaches:
-  *         instances:
-  *           - superb-visualization
-  *       lovable-lizards:
-  *         instances:
-  *           - apartment-cats
-  *
-  * The application is first looked up in the instances of the teams, if no team is found, owner is used as fallback.
-  * An error is thrown if the application is found belonging to multiple teams.
-  *
-  * \arg app
-  *    The application name. Can be the merged `inventory().params._instance` or an (aliased) application name.
-  * \return
-  *    The team name or `null` if no team is found.
-  */
-  teamForApplication: function(app)
-    local params = inv.parameters;
-    local lookup = function(app)
-      if std.objectHas(params, 'syn') && std.objectHas(params.syn, 'teams') then
-        local teams = params.syn.teams;
-        local teamsForApp = std.foldl(
-          function(prev, team)
-            if std.objectHas(teams, team) && std.objectHas(teams[team], 'instances') && std.member(com.renderArray(teams[team].instances), app) then
-              prev + [ team ]
-            else
-              prev,
-          std.objectFields(teams),
-          [],
-        );
-        if std.length(teamsForApp) == 0 then
-          null
-        else if std.length(teamsForApp) == 1 then
-          teamsForApp[0]
-        else
-          error 'application `%s` is in multiple teams: %s' % [ app, std.join(', ', teamsForApp) ];
-
-    local teams = std.prune(std.map(lookup, self.appKeys(app, true)));
-
-    if std.length(teams) > 0 then
-      teams[0]
-    else if std.objectHas(params, 'syn') && std.objectHas(params.syn, 'owner') then
-      params.syn.owner,
 
   /**
    * \brief Function to render rules defined in the hierarchy

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/10_alertmanager_config.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/10_alertmanager_config.yaml
@@ -44,7 +44,7 @@ stringData:
       - "continue": true
         "matchers":
         - "syn_team = \"\""
-        - "namespace =~ \"ns-string\""
+        - "namespace =~ \"ns-string|openshift-monitoring\""
         "receiver": "team_default_clumsy-donkeys"
       - "continue": true
         "matchers":
@@ -54,7 +54,7 @@ stringData:
       - "continue": false
         "matchers":
         - "syn_team = \"\""
-        - "namespace =~ \"base|overridden|ns-string|ns-object|same-ns\""
+        - "namespace =~ \"base|overridden|ns-string|openshift-monitoring|ns-object|same-ns\""
         "receiver": "__component_openshift4_monitoring_null"
       - "matchers":
         - "other = \"true\""

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/99_discovery_debug_cm.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/99_discovery_debug_cm.yaml
@@ -36,7 +36,7 @@ data:
       - "continue": true
         "matchers":
         - "syn_team = \"\""
-        - "namespace =~ \"ns-string\""
+        - "namespace =~ \"ns-string|openshift-monitoring\""
         "receiver": "team_default_clumsy-donkeys"
       - "continue": true
         "matchers":
@@ -46,14 +46,14 @@ data:
       - "continue": false
         "matchers":
         - "syn_team = \"\""
-        - "namespace =~ \"base|overridden|ns-string|ns-object|same-ns\""
+        - "namespace =~ \"base|overridden|ns-string|openshift-monitoring|ns-object|same-ns\""
         "receiver": "__component_openshift4_monitoring_null"
       - "matchers":
         - "other = \"true\""
         "receiver": "other"
       - "receiver": "team_default_clumsy-donkeys"
   applications: '["non-existing","no-ns","ns-string","ns-object","base as ns-in-base","base
-    as ns-overridden","non-existing as still-non-existing","same-ns-1","same-ns-2"]'
+    as ns-overridden","non-existing as still-non-existing","same-ns-1","same-ns-2","openshift4-monitoring"]'
   apps_without_namespaces: |-
     - "no-ns"
     - "non-existing"
@@ -66,6 +66,7 @@ data:
     "non-existing as still-non-existing": null
     "ns-object": "ns-object"
     "ns-string": "ns-string"
+    "openshift4-monitoring": "openshift-monitoring"
     "same-ns-1": "same-ns"
     "same-ns-2": "same-ns"
   discovered_teams: |-
@@ -76,6 +77,7 @@ data:
     "non-existing as still-non-existing": "clumsy-donkeys"
     "ns-object": "lovable-lizards"
     "ns-string": "clumsy-donkeys"
+    "openshift4-monitoring": "clumsy-donkeys"
     "same-ns-1": "lovable-lizards"
     "same-ns-2": "lovable-lizards"
   proposed_routes: |-
@@ -87,7 +89,7 @@ data:
     - "continue": true
       "matchers":
       - "syn_team = \"\""
-      - "namespace =~ \"ns-string\""
+      - "namespace =~ \"ns-string|openshift-monitoring\""
       "receiver": "team_default_clumsy-donkeys"
     - "continue": true
       "matchers":
@@ -97,7 +99,7 @@ data:
     - "continue": false
       "matchers":
       - "syn_team = \"\""
-      - "namespace =~ \"base|overridden|ns-string|ns-object|same-ns\""
+      - "namespace =~ \"base|overridden|ns-string|openshift-monitoring|ns-object|same-ns\""
       "receiver": "__component_openshift4_monitoring_null"
 kind: ConfigMap
 metadata:

--- a/tests/team-routing.yml
+++ b/tests/team-routing.yml
@@ -8,6 +8,7 @@ applications:
   - non-existing as still-non-existing
   - same-ns-1
   - same-ns-2
+  - openshift4-monitoring
 
 parameters:
   kapitan:


### PR DESCRIPTION
This PR switches the alert routing discovery and alert patching to use the new `syn-teams.libsonnet` Jsonnet library. This library is hosted at https://github.com/projectsyn/jsonnet-libs and is intended to be used by all components which interact with `parameters.syn.owner` and `parameters.syn.teams`.

## TODO

- [x] Switch to `version: 'main'` once https://github.com/projectsyn/jsonnet-libs/pull/1 is merged

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
