### PR TITLE
Update fields of `cluster-monitoring-config` for OpenShift 4.16 and newer

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -42,6 +42,7 @@ parameters:
               requests:
                 storage: 50Gi
       prometheusOperator: {}
+      prometheusOperatorAdmissionWebhook: {}
       alertmanagerMain:
         volumeClaimTemplate:
           spec:
@@ -49,12 +50,11 @@ parameters:
               requests:
                 storage: 2Gi
       kubeStateMetrics: {}
-      grafana: {}
       telemeterClient: {}
-      k8sPrometheusAdapter: {}
       openshiftStateMetrics: {}
       thanosQuerier: {}
       metricsServer: {}
+      monitoringPlugin: {}
     configsUserWorkload:
       alertmanager:
         enabled: true

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -95,15 +95,16 @@ This table shows the monitoring components you can configure and the keys used t
 |====
 |Component|Key
 |Prometheus Operator|`prometheusOperator`
+|Prometheus Operator admission webhook|`prometheusOperatorAdmissionWebhook`
 |Prometheus|`prometheusK8s`
 |Alertmanager|`alertmanagerMain`
 |kube-state-metrics|`kubeStateMetrics`
 |openshift-state-metrics|`openshiftStateMetrics`
-|Grafana|`grafana`
 |Telemeter Client|`telemeterClient`
-|Prometheus Adapter (for OpenShift 4.15 and older)|`k8sPrometheusAdapter`
-|Metrics Server (for OpenShift 4.16 and newer)|`metricsServer`
+|Metrics Server|`metricsServer`
 |Thanos Querier|`thanosQuerier`
+|Node exporter|`nodeExporter`
+|Console monitoring plugin|`monitoringPlugin`
 |====
 
 === `configs.prometheusK8s._remoteWrite`

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -10,16 +10,13 @@ data:
             "requests":
               "storage": "2Gi"
     "enableUserWorkload": true
-    "grafana":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
-    "k8sPrometheusAdapter":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "monitoringPlugin":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
@@ -40,6 +37,9 @@ data:
             "requests":
               "storage": "50Gi"
     "prometheusOperator":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "prometheusOperatorAdmissionWebhook":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "telemeterClient":

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -10,16 +10,13 @@ data:
             "requests":
               "storage": "2Gi"
     "enableUserWorkload": true
-    "grafana":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
-    "k8sPrometheusAdapter":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "monitoringPlugin":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
@@ -40,6 +37,9 @@ data:
             "requests":
               "storage": "50Gi"
     "prometheusOperator":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "prometheusOperatorAdmissionWebhook":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "telemeterClient":

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -10,16 +10,13 @@ data:
             "requests":
               "storage": "2Gi"
     "enableUserWorkload": true
-    "grafana":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
-    "k8sPrometheusAdapter":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "monitoringPlugin":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
@@ -40,6 +37,9 @@ data:
             "requests":
               "storage": "50Gi"
     "prometheusOperator":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "prometheusOperatorAdmissionWebhook":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "telemeterClient":

--- a/tests/golden/ovn-kubernetes/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/ovn-kubernetes/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -10,16 +10,13 @@ data:
             "requests":
               "storage": "2Gi"
     "enableUserWorkload": true
-    "grafana":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
-    "k8sPrometheusAdapter":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "monitoringPlugin":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
@@ -40,6 +37,9 @@ data:
             "requests":
               "storage": "50Gi"
     "prometheusOperator":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "prometheusOperatorAdmissionWebhook":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "telemeterClient":

--- a/tests/golden/release-4.16/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/release-4.16/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -10,16 +10,13 @@ data:
             "requests":
               "storage": "2Gi"
     "enableUserWorkload": true
-    "grafana":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
-    "k8sPrometheusAdapter":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "monitoringPlugin":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
@@ -40,6 +37,9 @@ data:
             "requests":
               "storage": "50Gi"
     "prometheusOperator":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "prometheusOperatorAdmissionWebhook":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "telemeterClient":

--- a/tests/golden/release-4.17/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/release-4.17/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -10,16 +10,13 @@ data:
             "requests":
               "storage": "2Gi"
     "enableUserWorkload": true
-    "grafana":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
-    "k8sPrometheusAdapter":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "monitoringPlugin":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
@@ -40,6 +37,9 @@ data:
             "requests":
               "storage": "50Gi"
     "prometheusOperator":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "prometheusOperatorAdmissionWebhook":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "telemeterClient":

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -10,16 +10,13 @@ data:
             "requests":
               "storage": "2Gi"
     "enableUserWorkload": true
-    "grafana":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
-    "k8sPrometheusAdapter":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "monitoringPlugin":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
@@ -68,6 +65,9 @@ data:
             "requests":
               "storage": "50Gi"
     "prometheusOperator":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "prometheusOperatorAdmissionWebhook":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "telemeterClient":

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -10,16 +10,13 @@ data:
             "requests":
               "storage": "2Gi"
     "enableUserWorkload": true
-    "grafana":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
-    "k8sPrometheusAdapter":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "monitoringPlugin":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
@@ -40,6 +37,9 @@ data:
             "requests":
               "storage": "50Gi"
     "prometheusOperator":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "prometheusOperatorAdmissionWebhook":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "telemeterClient":

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -10,16 +10,13 @@ data:
             "requests":
               "storage": "2Gi"
     "enableUserWorkload": true
-    "grafana":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
-    "k8sPrometheusAdapter":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "monitoringPlugin":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
@@ -40,6 +37,9 @@ data:
             "requests":
               "storage": "50Gi"
     "prometheusOperator":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "prometheusOperatorAdmissionWebhook":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "telemeterClient":

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -10,16 +10,13 @@ data:
             "requests":
               "storage": "2Gi"
     "enableUserWorkload": true
-    "grafana":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
-    "k8sPrometheusAdapter":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "kubeStateMetrics":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "metricsServer":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "monitoringPlugin":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "openshiftStateMetrics":
@@ -40,6 +37,9 @@ data:
             "requests":
               "storage": "50Gi"
     "prometheusOperator":
+      "nodeSelector":
+        "node-role.kubernetes.io/infra": ""
+    "prometheusOperatorAdmissionWebhook":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
     "telemeterClient":


### PR DESCRIPTION
We remove the unknown field `grafana` from cluster-monitoring-config defaults, because OpenShift 4.17 prints the following warning in `oc adm upgrade` when the `grafana` field is present in the `cluster-monitoring-config` configmap:

```
  Message: Cluster operator monitoring should not be upgraded between minor versions: configuration in the "openshift-monitoring/cluster-monitoring-config" ConfigMap is invalid and should be fixed: error unmarshaling JSON: while decoding JSON: json: unknown field "grafana"
```

Additionally, we add the missing fields `monitoringPlugin` and `prometheusOperatorAdmissionWebhook` so that those components also get the default node-selector config and remove the <=4.15 field `prometheusAdapter`.



## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
