### PR TITLE
Don't apply default config for `cluster-monitoring-config` fields which don't support `nodeSelector`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -42,7 +42,6 @@ parameters:
               requests:
                 storage: 50Gi
       prometheusOperator: {}
-      prometheusOperatorAdmissionWebhook: {}
       alertmanagerMain:
         volumeClaimTemplate:
           spec:

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -86,7 +86,15 @@ local cronjobs = import 'cronjobs.libsonnet';
             {
               enableUserWorkload: params.enableUserWorkload,
             } + std.mapWithKey(
-              function(field, value) params.defaultConfig + com.makeMergeable(value),
+              function(field, value)
+                if !std.member([ 'nodeExporter', 'prometheusOperatorAdmissionWebhook' ], field) then
+                  params.defaultConfig + com.makeMergeable(value)
+                else
+                  // fields `nodeExporter` and `prometheusOperatorAdmissionWebhook`
+                  // don't support field `nodeSelector` which we set in the
+                  // default config, so we don't apply the default config for
+                  // those fields.
+                  std.trace("Not applying default config for '%s'" % field, value),
               params.configs {
                 prometheusK8s: patchRemoteWrite(super.prometheusK8s, params.remoteWriteDefaults.cluster),
               }

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -35,6 +35,7 @@ nodeSelector:
 
 A dictionary holding the default configuration which should be applied to all components.
 
+NOTE: The contents of this parameter aren't applied to components `nodeExporter` and `prometheusOperatorAdmissionWebhook` which don't support field `nodeSelector`.
 
 == `upstreamRules.networkPlugin`
 

--- a/tests/custom-rules.yml
+++ b/tests/custom-rules.yml
@@ -13,6 +13,12 @@ parameters:
   openshift4_monitoring:
     manifests_version: release-4.16
 
+    # Validate that we don't inject the default nodeSelector for the fields
+    # that don't support it.
+    configs:
+      prometheusOperatorAdmissionWebhook: {}
+      nodeExporter: {}
+
     customNodeExporter:
       enabled: true
 

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -39,9 +39,6 @@ data:
     "prometheusOperator":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-    "prometheusOperatorAdmissionWebhook":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "telemeterClient":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -39,9 +39,6 @@ data:
     "prometheusOperator":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-    "prometheusOperatorAdmissionWebhook":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "telemeterClient":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -39,9 +39,6 @@ data:
     "prometheusOperator":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-    "prometheusOperatorAdmissionWebhook":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "telemeterClient":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/ovn-kubernetes/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/ovn-kubernetes/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -39,9 +39,6 @@ data:
     "prometheusOperator":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-    "prometheusOperatorAdmissionWebhook":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "telemeterClient":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/release-4.16/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/release-4.16/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -39,9 +39,6 @@ data:
     "prometheusOperator":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-    "prometheusOperatorAdmissionWebhook":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "telemeterClient":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/release-4.17/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/release-4.17/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -39,9 +39,6 @@ data:
     "prometheusOperator":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-    "prometheusOperatorAdmissionWebhook":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "telemeterClient":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -67,9 +67,6 @@ data:
     "prometheusOperator":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-    "prometheusOperatorAdmissionWebhook":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "telemeterClient":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -39,9 +39,6 @@ data:
     "prometheusOperator":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-    "prometheusOperatorAdmissionWebhook":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "telemeterClient":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -39,9 +39,6 @@ data:
     "prometheusOperator":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-    "prometheusOperatorAdmissionWebhook":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "telemeterClient":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/10_configmap.yaml
@@ -39,9 +39,6 @@ data:
     "prometheusOperator":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""
-    "prometheusOperatorAdmissionWebhook":
-      "nodeSelector":
-        "node-role.kubernetes.io/infra": ""
     "telemeterClient":
       "nodeSelector":
         "node-role.kubernetes.io/infra": ""


### PR DESCRIPTION
The fields `nodeSelector` and `prometheusOperatorAdmissionWebhook` don't support field `nodeSelector`, so we don't list them in `class/defaults.yml` and don't apply the default config if a user provides them.

When the fields are present, a informational message is emitted noting that the default config isn't applied to the fields.

Fixes #232 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
