### PR TITLE
Fix alert routing discovery when no namespaces are discovered for a team

### DIFF
--- a/component/alert-routing-discovery.libsonnet
+++ b/component/alert-routing-discovery.libsonnet
@@ -41,7 +41,10 @@ local ownerOrFallbackTeam =
     params.openshift4_monitoring.fallback_team;
 
 // teamToNS is a map from a team to namespaces.
-local teamToNS = std.mapWithKey(
+// The inner `std.prune()` is to drop `null` entries from a list that contains
+// a mix of null and non-null entries. The outer `std.prune()` drops teams
+// for which we haven't discovered any namespaces from the resulting object.
+local teamToNS = std.prune(std.mapWithKey(
   function(_, a) std.uniq(std.sort(std.prune(a))),
   std.foldl(
     function(prev, app)
@@ -51,7 +54,7 @@ local teamToNS = std.mapWithKey(
     inv.applications,
     {}
   )
-);
+));
 
 // teamBasedRouting contains discovered routes for teams.
 // The routes are set up with `continue: true` so we can route to multiple teams.

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -44,9 +44,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             min by (namespace,service, integration) (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             )
             > 0.01
           for: 5m
@@ -97,9 +97,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             )
             > 0.01
           for: 5m

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -44,9 +44,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             min by (namespace,service, integration) (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             )
             > 0.01
           for: 5m
@@ -97,9 +97,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             )
             > 0.01
           for: 5m

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -44,9 +44,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             min by (namespace,service, integration) (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             )
             > 0.01
           for: 5m
@@ -97,9 +97,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             )
             > 0.01
           for: 5m

--- a/tests/golden/ovn-kubernetes/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/ovn-kubernetes/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -44,9 +44,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             min by (namespace,service, integration) (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             )
             > 0.01
           for: 5m
@@ -97,9 +97,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             )
             > 0.01
           for: 5m

--- a/tests/golden/release-4.16/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/release-4.16/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -44,9 +44,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             min by (namespace,service, integration) (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             )
             > 0.01
           for: 5m
@@ -97,9 +97,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             )
             > 0.01
           for: 5m

--- a/tests/golden/release-4.17/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/release-4.17/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -44,9 +44,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             min by (namespace,service, integration) (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             )
             > 0.01
           for: 5m
@@ -97,9 +97,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             )
             > 0.01
           for: 5m

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -44,9 +44,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             min by (namespace,service, integration) (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             )
             > 0.01
           for: 5m
@@ -97,9 +97,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             )
             > 0.01
           for: 5m

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/99_discovery_debug_cm.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/99_discovery_debug_cm.yaml
@@ -53,15 +53,20 @@ data:
         "receiver": "other"
       - "receiver": "team_default_clumsy-donkeys"
   applications: '["non-existing","no-ns","ns-string","ns-object","base as ns-in-base","base
-    as ns-overridden","non-existing as still-non-existing","same-ns-1","same-ns-2","openshift4-monitoring"]'
+    as ns-overridden","non-existing as still-non-existing","same-ns-1","same-ns-2","openshift4-monitoring","no-ns
+    as no-ns-team","no-ns as no-ns-team2"]'
   apps_without_namespaces: |-
     - "no-ns"
+    - "no-ns as no-ns-team"
+    - "no-ns as no-ns-team2"
     - "non-existing"
     - "non-existing as still-non-existing"
   discovered_namespaces: |-
     "base as ns-in-base": "base"
     "base as ns-overridden": "overridden"
     "no-ns": null
+    "no-ns as no-ns-team": null
+    "no-ns as no-ns-team2": null
     "non-existing": null
     "non-existing as still-non-existing": null
     "ns-object": "ns-object"
@@ -73,6 +78,8 @@ data:
     "base as ns-in-base": "chubby-cockroaches"
     "base as ns-overridden": "chubby-cockroaches"
     "no-ns": "clumsy-donkeys"
+    "no-ns as no-ns-team": "sleepy-badgers"
+    "no-ns as no-ns-team2": "lovable-lizards"
     "non-existing": "clumsy-donkeys"
     "non-existing as still-non-existing": "clumsy-donkeys"
     "ns-object": "lovable-lizards"

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -45,9 +45,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             min by (namespace,service, integration) (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             )
             > 0.01
           for: 5m
@@ -101,9 +101,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             )
             > 0.01
           for: 5m

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -44,9 +44,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             min by (namespace,service, integration) (
-              rate(alertmanager_notifications_failed_total{job="alertmanager-main", integration=~`.*`}[5m])
+              rate(alertmanager_notifications_failed_total{job="alertmanager-main", integration=~`.*`}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main", integration=~`.*`}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main", integration=~`.*`}[15m])
             )
             > 0.01
           for: 5m
@@ -97,9 +97,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (
-              rate(alertmanager_notifications_failed_total{job="alertmanager-main"}[5m])
+              rate(alertmanager_notifications_failed_total{job="alertmanager-main"}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main"}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main"}[15m])
             )
             > 0.01
           for: 5m

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -44,9 +44,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             min by (namespace,service, integration) (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
             )
             > 0.01
           for: 5m
@@ -97,9 +97,9 @@ spec:
             syn_component: openshift4-monitoring
           expr: |
             (
-              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             /
-              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+              ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
             )
             > 0.01
           for: 5m

--- a/tests/team-routing.yml
+++ b/tests/team-routing.yml
@@ -9,6 +9,8 @@ applications:
   - same-ns-1
   - same-ns-2
   - openshift4-monitoring
+  - no-ns as no-ns-team
+  - no-ns as no-ns-team2
 
 parameters:
   kapitan:
@@ -36,6 +38,10 @@ parameters:
           - same-ns-2
           - ns-in-base
           - ~ns-in-base
+          - no-ns-team2
+      sleepy-badgers:
+        instances:
+          - no-ns-team
 
   openshift4_monitoring:
     alertManagerConfig:


### PR DESCRIPTION
The alert routing discovery logic collects all namespaces referenced in component instances assigned to each team. Until now, we didn't consider the case where all instances assigned to a team would reference no namespaces. In such a case the discovery would generate a routing rule such as

```
  - "continue": true
    "matchers":
    - "syn_team = \"\""
    - "namespace =~ \"\""
    "receiver": "team_default_<teamname>"
```

This PR adjusts the namespace discovery to drop team to namespace map entries whose values are empty or null.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
