### PR TITLE
Fix alert routing namespace discovery logic

### DIFF
--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -275,8 +275,17 @@ alertManagerAutoDiscovery:
 
 The auto-discovery routes alerts to the configured teams based on their namespaces and the top-level `syn.teams[*].instances` and `syn.owner` parameters.
 Auto-discovery first creates a list of Commodore component instances by parsing the `applications` array using the same rules as Commodore itself (see also the https://syn.tools/commodore/reference/architecture.html#_component_instantiation[Commodore component instantiation documentation]).
-For each discovered instance, the component then renders the instance parameters, and reads the cmoponent's namespace from field `namespace` or `namespace.name` in the rendered parameters.
+For each discovered instance, the component then reads the component's namespace from field `namespace` or `namespace.name` in the rendered parameters of this component.
 Finally, routing rules are generated to route alerts from the discovered namespaces to the associated component instance's owning team.
+
+[NOTE]
+====
+Without special handling, the namespace discovery would discover namespace `openshift4-monitoring` for component instances that use `namespace: ${_instance}`.
+This is the case because we read the instance's namespace from the rendered parameters for component openshift4-monitoring and therefore `${_instance}` resolves to `openshift4-monitoring`.
+
+To address this case, the component has override logic in the namespace discovery for component instances which use `${_instance}` in their namespace definition.
+The override logic replaces all occurrences of `openshift4-monitoring` in the discovered namespace with the instance name for instances other than `openshift4-monitoring`.
+====
 
 .`syn` Team Example
 [source,yaml]

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -922,13 +922,13 @@ spec:
                   unless
                 kube_statefulset_status_update_revision{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-                *
+                * on(namespace, statefulset, job, cluster)
               (
                 kube_statefulset_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
                   !=
                 kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-            )  and (
+            )  and on(namespace, statefulset, job, cluster) (
               changes(kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}[5m])
                 ==
               0

--- a/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/capacity-alerts/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -922,13 +922,13 @@ spec:
                   unless
                 kube_statefulset_status_update_revision{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-                *
+                * on(namespace, statefulset, job, cluster)
               (
                 kube_statefulset_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
                   !=
                 kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-            )  and (
+            )  and on(namespace, statefulset, job, cluster) (
               changes(kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}[5m])
                 ==
               0

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -907,13 +907,13 @@ spec:
                   unless
                 kube_statefulset_status_update_revision{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
               )
-                *
+                * on(namespace, statefulset, job, cluster)
               (
                 kube_statefulset_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
                   !=
                 kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}
               )
-            )  and (
+            )  and on(namespace, statefulset, job, cluster) (
               changes(kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",namespace!~"(openshift-adp)",job="kube-state-metrics"}[5m])
                 ==
               0

--- a/tests/golden/ovn-kubernetes/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/ovn-kubernetes/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -1073,13 +1073,13 @@ spec:
                   unless
                 kube_statefulset_status_update_revision{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-                *
+                * on(namespace, statefulset, job, cluster)
               (
                 kube_statefulset_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
                   !=
                 kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-            )  and (
+            )  and on(namespace, statefulset, job, cluster) (
               changes(kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}[5m])
                 ==
               0

--- a/tests/golden/release-4.16/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/release-4.16/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -904,13 +904,13 @@ spec:
                   unless
                 kube_statefulset_status_update_revision{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-                *
+                * on(namespace, statefulset, job, cluster)
               (
                 kube_statefulset_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
                   !=
                 kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-            )  and (
+            )  and on(namespace, statefulset, job, cluster) (
               changes(kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}[5m])
                 ==
               0

--- a/tests/golden/release-4.17/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/release-4.17/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -922,13 +922,13 @@ spec:
                   unless
                 kube_statefulset_status_update_revision{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-                *
+                * on(namespace, statefulset, job, cluster)
               (
                 kube_statefulset_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
                   !=
                 kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-            )  and (
+            )  and on(namespace, statefulset, job, cluster) (
               changes(kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}[5m])
                 ==
               0

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -922,13 +922,13 @@ spec:
                   unless
                 kube_statefulset_status_update_revision{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-                *
+                * on(namespace, statefulset, job, cluster)
               (
                 kube_statefulset_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
                   !=
                 kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-            )  and (
+            )  and on(namespace, statefulset, job, cluster) (
               changes(kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}[5m])
                 ==
               0

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/10_alertmanager_config.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/10_alertmanager_config.yaml
@@ -44,7 +44,7 @@ stringData:
       - "continue": true
         "matchers":
         - "syn_team = \"\""
-        - "namespace =~ \"ns-string|openshift-monitoring\""
+        - "namespace =~ \"instance-ns|ns-string|openshift-monitoring\""
         "receiver": "team_default_clumsy-donkeys"
       - "continue": true
         "matchers":
@@ -54,7 +54,7 @@ stringData:
       - "continue": false
         "matchers":
         - "syn_team = \"\""
-        - "namespace =~ \"base|overridden|ns-string|openshift-monitoring|ns-object|same-ns\""
+        - "namespace =~ \"base|overridden|instance-ns|ns-string|openshift-monitoring|ns-object|same-ns\""
         "receiver": "__component_openshift4_monitoring_null"
       - "matchers":
         - "other = \"true\""

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/99_discovery_debug_cm.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/99_discovery_debug_cm.yaml
@@ -36,7 +36,7 @@ data:
       - "continue": true
         "matchers":
         - "syn_team = \"\""
-        - "namespace =~ \"ns-string|openshift-monitoring\""
+        - "namespace =~ \"instance-ns|ns-string|openshift-monitoring\""
         "receiver": "team_default_clumsy-donkeys"
       - "continue": true
         "matchers":
@@ -46,7 +46,7 @@ data:
       - "continue": false
         "matchers":
         - "syn_team = \"\""
-        - "namespace =~ \"base|overridden|ns-string|openshift-monitoring|ns-object|same-ns\""
+        - "namespace =~ \"base|overridden|instance-ns|ns-string|openshift-monitoring|ns-object|same-ns\""
         "receiver": "__component_openshift4_monitoring_null"
       - "matchers":
         - "other = \"true\""
@@ -54,7 +54,7 @@ data:
       - "receiver": "team_default_clumsy-donkeys"
   applications: '["non-existing","no-ns","ns-string","ns-object","base as ns-in-base","base
     as ns-overridden","non-existing as still-non-existing","same-ns-1","same-ns-2","openshift4-monitoring","no-ns
-    as no-ns-team","no-ns as no-ns-team2"]'
+    as no-ns-team","no-ns as no-ns-team2","instance-ns"]'
   apps_without_namespaces: |-
     - "no-ns"
     - "no-ns as no-ns-team"
@@ -64,6 +64,7 @@ data:
   discovered_namespaces: |-
     "base as ns-in-base": "base"
     "base as ns-overridden": "overridden"
+    "instance-ns": "instance-ns"
     "no-ns": null
     "no-ns as no-ns-team": null
     "no-ns as no-ns-team2": null
@@ -77,6 +78,7 @@ data:
   discovered_teams: |-
     "base as ns-in-base": "chubby-cockroaches"
     "base as ns-overridden": "chubby-cockroaches"
+    "instance-ns": "clumsy-donkeys"
     "no-ns": "clumsy-donkeys"
     "no-ns as no-ns-team": "sleepy-badgers"
     "no-ns as no-ns-team2": "lovable-lizards"
@@ -96,7 +98,7 @@ data:
     - "continue": true
       "matchers":
       - "syn_team = \"\""
-      - "namespace =~ \"ns-string|openshift-monitoring\""
+      - "namespace =~ \"instance-ns|ns-string|openshift-monitoring\""
       "receiver": "team_default_clumsy-donkeys"
     - "continue": true
       "matchers":
@@ -106,7 +108,7 @@ data:
     - "continue": false
       "matchers":
       - "syn_team = \"\""
-      - "namespace =~ \"base|overridden|ns-string|openshift-monitoring|ns-object|same-ns\""
+      - "namespace =~ \"base|overridden|instance-ns|ns-string|openshift-monitoring|ns-object|same-ns\""
       "receiver": "__component_openshift4_monitoring_null"
 kind: ConfigMap
 metadata:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -969,13 +969,13 @@ spec:
                   unless
                 kube_statefulset_status_update_revision{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-                *
+                * on(namespace, statefulset, job, cluster)
               (
                 kube_statefulset_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
                   !=
                 kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-            )  and (
+            )  and on(namespace, statefulset, job, cluster) (
               changes(kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}[5m])
                 ==
               0

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -922,13 +922,13 @@ spec:
                   unless
                 kube_statefulset_status_update_revision{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-                *
+                * on(namespace, statefulset, job, cluster)
               (
                 kube_statefulset_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
                   !=
                 kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-            )  and (
+            )  and on(namespace, statefulset, job, cluster) (
               changes(kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}[5m])
                 ==
               0

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/prometheus_rules.yaml
@@ -922,13 +922,13 @@ spec:
                   unless
                 kube_statefulset_status_update_revision{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-                *
+                * on(namespace, statefulset, job, cluster)
               (
                 kube_statefulset_replicas{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
                   !=
                 kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}
               )
-            )  and (
+            )  and on(namespace, statefulset, job, cluster) (
               changes(kube_statefulset_status_replicas_updated{namespace=~"(appuio.*|cilium|default|kube-.*|openshift-.*|syn.*)",job="kube-state-metrics"}[5m])
                 ==
               0

--- a/tests/team-routing.yml
+++ b/tests/team-routing.yml
@@ -11,6 +11,7 @@ applications:
   - openshift4-monitoring
   - no-ns as no-ns-team
   - no-ns as no-ns-team2
+  - instance-ns
 
 parameters:
   kapitan:
@@ -96,3 +97,7 @@ parameters:
 
   same_ns_2:
     namespace: same-ns
+
+  instance_ns:
+    # This will resolve to `instance-ns` or an instance when rendering the actual namespace
+    namespace: ${_instance}


### PR DESCRIPTION
We tend to use `namespace: ${_instance}` for components where we deploy each instance in a separate namespace (e.g. component-vault, component-openshift4-operators). However, because we read the instance namespaces from openshift4-monitoring's parameters, `${_instance}` is resolved to `openshift4-monitoring` and not to the component instance name.

This commit updates the discovery logic to override the discovered namespace if we discover a namespace that contains
`openshift4-monitoring` for any app other than `openshift4-monitoring` itself. The new override logic replaces all occurrences of `openshift4-monitoring` in the discovered namespace with the parsed component instance name.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
