### PR TITLE
Remove previously silenced `NodeCpuLoad5` alert

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -168,7 +168,6 @@ parameters:
         - ThanosQueryHighDNSFailures
         - ThanosRuleAlertmanagerHighDNSFailures
         - ThanosRuleQueryHighDNSFailures
-        - node_cpu_load5
       ignoreWarnings:
         - ExtremelyHighIndividualControlPlaneCPU
         - MachineConfigControllerPausedPoolKubeletCA
@@ -251,13 +250,6 @@ parameters:
 
     rules:
       node-utilization:
-        "alert:NodeCpuLoad5":
-          expr: 'max by(instance) (node_load5) / count by(instance) (node_cpu_info) > 2'
-          for: '30m'
-          labels:
-            severity: 'critical'
-          annotations:
-            message: '{{ $labels.instance }}: Load higher than 2 (current value is: {{ $value }})'
         "alert:NodeMemoryFreePercent":
           expr: '(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes > 0.97'
           for: '30m'

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -149,8 +149,7 @@ spec:
               "ThanosQueryGrpcServerErrorRate",
               "ThanosQueryHighDNSFailures",
               "ThanosRuleAlertmanagerHighDNSFailures",
-              "ThanosRuleQueryHighDNSFailures",
-              "node_cpu_load5"
+              "ThanosRuleQueryHighDNSFailures"
           ],
           "ignoreUserWorkload": [
 

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/50_rules_additional.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/50_rules_additional.yaml
@@ -9,17 +9,6 @@ spec:
   groups:
     - name: node-utilization
       rules:
-        - alert: NodeCpuLoad5
-          annotations:
-            message: '{{ $labels.instance }}: Load higher than 2 (current value is:
-              {{ $value }})'
-          expr: max by(instance) (node_load5) / count by(instance) (node_cpu_info)
-            > 2
-          for: 30m
-          labels:
-            severity: critical
-            syn: 'true'
-            syn_component: openshift4-monitoring
         - alert: NodeMemoryFreePercent
           annotations:
             message: '{{ $labels.instance }}: Memory usage more than 97% (current

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -149,8 +149,7 @@ spec:
               "ThanosQueryGrpcServerErrorRate",
               "ThanosQueryHighDNSFailures",
               "ThanosRuleAlertmanagerHighDNSFailures",
-              "ThanosRuleQueryHighDNSFailures",
-              "node_cpu_load5"
+              "ThanosRuleQueryHighDNSFailures"
           ],
           "ignoreUserWorkload": [
 

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/50_rules_additional.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/50_rules_additional.yaml
@@ -34,17 +34,6 @@ spec:
             syn_component: openshift4-monitoring
     - name: node-utilization
       rules:
-        - alert: NodeCpuLoad5
-          annotations:
-            message: '{{ $labels.instance }}: Load higher than 2 (current value is:
-              {{ $value }})'
-          expr: max by(instance) (node_load5) / count by(instance) (node_cpu_info)
-            > 2
-          for: 30m
-          labels:
-            severity: critical
-            syn: 'true'
-            syn_component: openshift4-monitoring
         - alert: NodeMemoryFreePercent
           annotations:
             message: '{{ $labels.instance }}: Memory usage more than 97% (current

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -149,8 +149,7 @@ spec:
               "ThanosQueryGrpcServerErrorRate",
               "ThanosQueryHighDNSFailures",
               "ThanosRuleAlertmanagerHighDNSFailures",
-              "ThanosRuleQueryHighDNSFailures",
-              "node_cpu_load5"
+              "ThanosRuleQueryHighDNSFailures"
           ],
           "ignoreUserWorkload": [
 

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/50_rules_additional.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/50_rules_additional.yaml
@@ -9,17 +9,6 @@ spec:
   groups:
     - name: node-utilization
       rules:
-        - alert: NodeCpuLoad5
-          annotations:
-            message: '{{ $labels.instance }}: Load higher than 2 (current value is:
-              {{ $value }})'
-          expr: max by(instance) (node_load5) / count by(instance) (node_cpu_info)
-            > 2
-          for: 30m
-          labels:
-            severity: critical
-            syn: 'true'
-            syn_component: openshift4-monitoring
         - alert: NodeMemoryFreePercent
           annotations:
             message: '{{ $labels.instance }}: Memory usage more than 97% (current

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -149,8 +149,7 @@ spec:
               "ThanosQueryGrpcServerErrorRate",
               "ThanosQueryHighDNSFailures",
               "ThanosRuleAlertmanagerHighDNSFailures",
-              "ThanosRuleQueryHighDNSFailures",
-              "node_cpu_load5"
+              "ThanosRuleQueryHighDNSFailures"
           ],
           "ignoreUserWorkload": [
 

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/50_rules_additional.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/50_rules_additional.yaml
@@ -9,17 +9,6 @@ spec:
   groups:
     - name: node-utilization
       rules:
-        - alert: NodeCpuLoad5
-          annotations:
-            message: '{{ $labels.instance }}: Load higher than 2 (current value is:
-              {{ $value }})'
-          expr: max by(instance) (node_load5) / count by(instance) (node_cpu_info)
-            > 2
-          for: 30m
-          labels:
-            severity: critical
-            syn: 'true'
-            syn_component: openshift4-monitoring
         - alert: NodeMemoryFreePercent
           annotations:
             message: '{{ $labels.instance }}: Memory usage more than 97% (current

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -149,8 +149,7 @@ spec:
               "ThanosQueryGrpcServerErrorRate",
               "ThanosQueryHighDNSFailures",
               "ThanosRuleAlertmanagerHighDNSFailures",
-              "ThanosRuleQueryHighDNSFailures",
-              "node_cpu_load5"
+              "ThanosRuleQueryHighDNSFailures"
           ],
           "ignoreUserWorkload": [
 

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/50_rules_additional.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/50_rules_additional.yaml
@@ -25,18 +25,6 @@ spec:
             syn_team: clumsy-donkeys
     - name: node-utilization
       rules:
-        - alert: NodeCpuLoad5
-          annotations:
-            message: '{{ $labels.instance }}: Load higher than 2 (current value is:
-              {{ $value }})'
-          expr: max by(instance) (node_load5) / count by(instance) (node_cpu_info)
-            > 2
-          for: 30m
-          labels:
-            severity: critical
-            syn: 'true'
-            syn_component: openshift4-monitoring
-            syn_team: clumsy-donkeys
         - alert: NodeMemoryFreePercent
           annotations:
             message: '{{ $labels.instance }}: Memory usage more than 97% (current

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -149,8 +149,7 @@ spec:
               "ThanosQueryGrpcServerErrorRate",
               "ThanosQueryHighDNSFailures",
               "ThanosRuleAlertmanagerHighDNSFailures",
-              "ThanosRuleQueryHighDNSFailures",
-              "node_cpu_load5"
+              "ThanosRuleQueryHighDNSFailures"
           ],
           "ignoreUserWorkload": [
               "AlertmanagerFailedToSendAlerts",

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/50_rules_additional.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/50_rules_additional.yaml
@@ -9,17 +9,6 @@ spec:
   groups:
     - name: node-utilization
       rules:
-        - alert: NodeCpuLoad5
-          annotations:
-            message: '{{ $labels.instance }}: Load higher than 2 (current value is:
-              {{ $value }})'
-          expr: max by(instance) (node_load5) / count by(instance) (node_cpu_info)
-            > 2
-          for: 30m
-          labels:
-            severity: critical
-            syn: 'true'
-            syn_component: openshift4-monitoring
         - alert: NodeMemoryFreePercent
           annotations:
             message: '{{ $labels.instance }}: Memory usage more than 97% (current

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -149,8 +149,7 @@ spec:
               "ThanosQueryGrpcServerErrorRate",
               "ThanosQueryHighDNSFailures",
               "ThanosRuleAlertmanagerHighDNSFailures",
-              "ThanosRuleQueryHighDNSFailures",
-              "node_cpu_load5"
+              "ThanosRuleQueryHighDNSFailures"
           ],
           "ignoreUserWorkload": [
 

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/50_rules_additional.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/50_rules_additional.yaml
@@ -9,17 +9,6 @@ spec:
   groups:
     - name: node-utilization
       rules:
-        - alert: NodeCpuLoad5
-          annotations:
-            message: '{{ $labels.instance }}: Load higher than 2 (current value is:
-              {{ $value }})'
-          expr: max by(instance) (node_load5) / count by(instance) (node_cpu_info)
-            > 2
-          for: 30m
-          labels:
-            severity: critical
-            syn: 'true'
-            syn_component: openshift4-monitoring
         - alert: NodeMemoryFreePercent
           annotations:
             message: '{{ $labels.instance }}: Memory usage more than 97% (current


### PR DESCRIPTION
We had the old version of this alert (`node_cpu_load5`) in the list of ignored alerts (probably because we forgot that we deployed it ourselves). Since it got renamed for v7.0.0, it didn't get dropped anymore.

Instead of updating the ignore list, we simply remove the custom alert rule completely.

Tagged as a `bug` because this restores v6 default behavior.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
