### PR TITLE
Drop recording rules when copying upstream alerts

### DIFF
--- a/lib/openshift4-monitoring-operator-rules.libsonnet
+++ b/lib/openshift4-monitoring-operator-rules.libsonnet
@@ -215,16 +215,20 @@ local managedResource(ns) = esp.managedResource(global_name, ns) {
           local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
           if std.length(cand) > 0 then cand[0];
 
-        if or != null && !inDelete(or) then [
-          renderer.process(or, configGlobal, configComponent)
+        if or != null && !inDelete(or) then
+          local proc = renderer.process(or, configGlobal, configComponent);
+          if proc != null then
+            proc
+      )
+      else std.filter(
+        function(r) r != null,
+        [
+          // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+          renderer.process(or, configGlobal, configComponent),
+          for or in opRules
+          if !inDelete(or)
         ]
       )
-      else [
-        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-        renderer.process(or, configGlobal, configComponent),
-        for or in opRules
-        if !inDelete(or)
-      ]
     |||,
   },
 };

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_cloud-credential-operator.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_cloud-credential-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-machine-approver.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-machine-approver.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-node-tuning-operator.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-node-tuning-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-samples-operator.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-samples-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-storage-operator.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-storage-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-version.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-version.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_console-operator.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_console-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_dns-operator.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_dns-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_etcd-operator.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_etcd-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -357,21 +357,26 @@ spec:
               config.ignoreNames,
               std.get(r, 'alert', '')
             )
-          );
+          ) ||
+          // drop all recording rules
+          std.objectHas(r, 'record');
         group {
           rules: std.filter(function(rule) !drop(rule), super.rules),
         };
 
-      local processGroup(group, config) = std.foldl(
-        function(g, func) func(g, config),
-        [
-          procFilterRules,
-          procPatchExprSelector,
-          procPatchExprUserWorkload,
-          procPatchRules,
-        ],
-        group
-      );
+      local processGroup(group, config) =
+        local processed = std.foldl(
+          function(g, func) func(g, config),
+          [
+            procFilterRules,
+            procPatchExprSelector,
+            procPatchExprUserWorkload,
+            procPatchRules,
+          ],
+          group
+        );
+        if std.length(processed.rules) > 0 then
+          processed;
 
       local process(rule, configGlobal, configComponent, enableOwnerRefrences=true) =
         local config = {
@@ -389,7 +394,7 @@ spec:
           renderedExcludeSelector: std.join('|', renderArray(configGlobal.excludeNamespaces + std.get(configComponent, 'excludeNamespaces', []))),
           componentName: std.get(configComponent, 'component', 'openshift4-monitoring'),
         };
-        {
+        local result = {
           apiVersion: 'monitoring.coreos.com/v1',
           kind: 'PrometheusRule',
           metadata: {
@@ -407,14 +412,19 @@ spec:
             namespace: rule.metadata.namespace,
           },
           spec: {
-            groups: [
-              // Process each group and drop groups in `config.ignoreGroups`
-              processGroup(group, config)
-              for group in rule.spec.groups
-              if !std.member(config.ignoreGroups, group.name)
-            ],
+            groups: std.filter(
+              function(g) g != null,
+              [
+                // Process each group and drop groups in `config.ignoreGroups`
+                processGroup(group, config)
+                for group in rule.spec.groups
+                if !std.member(config.ignoreGroups, group.name)
+              ]
+            ),
           },
         };
+        if std.length(result.spec.groups) > 0 then
+          result;
 
       {
         process: process,

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_image-registry.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_image-registry.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_ingress-operator.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_ingress-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_insights.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_insights.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver-operator.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-controller-manager-operator.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-controller-manager-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-scheduler-operator.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-scheduler-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-api.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-api.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-config-operator.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-config-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_monitoring.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_monitoring.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_multus.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_multus.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_network-operator.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_network-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_operator-lifecycle-manager.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_operator-lifecycle-manager.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_operators-redhat.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_operators-redhat.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_user-workload-monitoring.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_user-workload-monitoring.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_cloud-credential-operator.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_cloud-credential-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-machine-approver.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-machine-approver.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-node-tuning-operator.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-node-tuning-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-samples-operator.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-samples-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-storage-operator.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-storage-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-version.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-version.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_console-operator.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_console-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_dns-operator.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_dns-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_etcd-operator.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_etcd-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -361,21 +361,26 @@ spec:
               config.ignoreNames,
               std.get(r, 'alert', '')
             )
-          );
+          ) ||
+          // drop all recording rules
+          std.objectHas(r, 'record');
         group {
           rules: std.filter(function(rule) !drop(rule), super.rules),
         };
 
-      local processGroup(group, config) = std.foldl(
-        function(g, func) func(g, config),
-        [
-          procFilterRules,
-          procPatchExprSelector,
-          procPatchExprUserWorkload,
-          procPatchRules,
-        ],
-        group
-      );
+      local processGroup(group, config) =
+        local processed = std.foldl(
+          function(g, func) func(g, config),
+          [
+            procFilterRules,
+            procPatchExprSelector,
+            procPatchExprUserWorkload,
+            procPatchRules,
+          ],
+          group
+        );
+        if std.length(processed.rules) > 0 then
+          processed;
 
       local process(rule, configGlobal, configComponent, enableOwnerRefrences=true) =
         local config = {
@@ -393,7 +398,7 @@ spec:
           renderedExcludeSelector: std.join('|', renderArray(configGlobal.excludeNamespaces + std.get(configComponent, 'excludeNamespaces', []))),
           componentName: std.get(configComponent, 'component', 'openshift4-monitoring'),
         };
-        {
+        local result = {
           apiVersion: 'monitoring.coreos.com/v1',
           kind: 'PrometheusRule',
           metadata: {
@@ -411,14 +416,19 @@ spec:
             namespace: rule.metadata.namespace,
           },
           spec: {
-            groups: [
-              // Process each group and drop groups in `config.ignoreGroups`
-              processGroup(group, config)
-              for group in rule.spec.groups
-              if !std.member(config.ignoreGroups, group.name)
-            ],
+            groups: std.filter(
+              function(g) g != null,
+              [
+                // Process each group and drop groups in `config.ignoreGroups`
+                processGroup(group, config)
+                for group in rule.spec.groups
+                if !std.member(config.ignoreGroups, group.name)
+              ]
+            ),
           },
         };
+        if std.length(result.spec.groups) > 0 then
+          result;
 
       {
         process: process,

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_image-registry.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_image-registry.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_ingress-operator.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_ingress-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_insights.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_insights.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver-operator.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-controller-manager-operator.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-controller-manager-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-scheduler-operator.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-scheduler-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-api.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-api.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-config-operator.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-config-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_monitoring.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_monitoring.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_multus.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_multus.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_network-operator.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_network-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_operator-lifecycle-manager.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_operator-lifecycle-manager.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_operators-redhat.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_operators-redhat.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_user-workload-monitoring.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_user-workload-monitoring.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_cloud-credential-operator.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_cloud-credential-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-machine-approver.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-machine-approver.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-node-tuning-operator.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-node-tuning-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-samples-operator.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-samples-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-storage-operator.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-storage-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-version.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-version.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_console-operator.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_console-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_dns-operator.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_dns-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_etcd-operator.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_etcd-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -357,21 +357,26 @@ spec:
               config.ignoreNames,
               std.get(r, 'alert', '')
             )
-          );
+          ) ||
+          // drop all recording rules
+          std.objectHas(r, 'record');
         group {
           rules: std.filter(function(rule) !drop(rule), super.rules),
         };
 
-      local processGroup(group, config) = std.foldl(
-        function(g, func) func(g, config),
-        [
-          procFilterRules,
-          procPatchExprSelector,
-          procPatchExprUserWorkload,
-          procPatchRules,
-        ],
-        group
-      );
+      local processGroup(group, config) =
+        local processed = std.foldl(
+          function(g, func) func(g, config),
+          [
+            procFilterRules,
+            procPatchExprSelector,
+            procPatchExprUserWorkload,
+            procPatchRules,
+          ],
+          group
+        );
+        if std.length(processed.rules) > 0 then
+          processed;
 
       local process(rule, configGlobal, configComponent, enableOwnerRefrences=true) =
         local config = {
@@ -389,7 +394,7 @@ spec:
           renderedExcludeSelector: std.join('|', renderArray(configGlobal.excludeNamespaces + std.get(configComponent, 'excludeNamespaces', []))),
           componentName: std.get(configComponent, 'component', 'openshift4-monitoring'),
         };
-        {
+        local result = {
           apiVersion: 'monitoring.coreos.com/v1',
           kind: 'PrometheusRule',
           metadata: {
@@ -407,14 +412,19 @@ spec:
             namespace: rule.metadata.namespace,
           },
           spec: {
-            groups: [
-              // Process each group and drop groups in `config.ignoreGroups`
-              processGroup(group, config)
-              for group in rule.spec.groups
-              if !std.member(config.ignoreGroups, group.name)
-            ],
+            groups: std.filter(
+              function(g) g != null,
+              [
+                // Process each group and drop groups in `config.ignoreGroups`
+                processGroup(group, config)
+                for group in rule.spec.groups
+                if !std.member(config.ignoreGroups, group.name)
+              ]
+            ),
           },
         };
+        if std.length(result.spec.groups) > 0 then
+          result;
 
       {
         process: process,

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_image-registry.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_image-registry.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_ingress-operator.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_ingress-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_insights.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_insights.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver-operator.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-controller-manager-operator.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-controller-manager-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-scheduler-operator.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-scheduler-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-api.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-api.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-config-operator.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-config-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_monitoring.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_monitoring.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_multus.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_multus.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_network-operator.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_network-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_operator-lifecycle-manager.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_operator-lifecycle-manager.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_operators-redhat.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_operators-redhat.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_user-workload-monitoring.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_user-workload-monitoring.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_cloud-credential-operator.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_cloud-credential-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-machine-approver.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-machine-approver.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-node-tuning-operator.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-node-tuning-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-samples-operator.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-samples-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-storage-operator.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-storage-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-version.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-version.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_console-operator.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_console-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_dns-operator.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_dns-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_etcd-operator.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_etcd-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -357,21 +357,26 @@ spec:
               config.ignoreNames,
               std.get(r, 'alert', '')
             )
-          );
+          ) ||
+          // drop all recording rules
+          std.objectHas(r, 'record');
         group {
           rules: std.filter(function(rule) !drop(rule), super.rules),
         };
 
-      local processGroup(group, config) = std.foldl(
-        function(g, func) func(g, config),
-        [
-          procFilterRules,
-          procPatchExprSelector,
-          procPatchExprUserWorkload,
-          procPatchRules,
-        ],
-        group
-      );
+      local processGroup(group, config) =
+        local processed = std.foldl(
+          function(g, func) func(g, config),
+          [
+            procFilterRules,
+            procPatchExprSelector,
+            procPatchExprUserWorkload,
+            procPatchRules,
+          ],
+          group
+        );
+        if std.length(processed.rules) > 0 then
+          processed;
 
       local process(rule, configGlobal, configComponent, enableOwnerRefrences=true) =
         local config = {
@@ -389,7 +394,7 @@ spec:
           renderedExcludeSelector: std.join('|', renderArray(configGlobal.excludeNamespaces + std.get(configComponent, 'excludeNamespaces', []))),
           componentName: std.get(configComponent, 'component', 'openshift4-monitoring'),
         };
-        {
+        local result = {
           apiVersion: 'monitoring.coreos.com/v1',
           kind: 'PrometheusRule',
           metadata: {
@@ -407,14 +412,19 @@ spec:
             namespace: rule.metadata.namespace,
           },
           spec: {
-            groups: [
-              // Process each group and drop groups in `config.ignoreGroups`
-              processGroup(group, config)
-              for group in rule.spec.groups
-              if !std.member(config.ignoreGroups, group.name)
-            ],
+            groups: std.filter(
+              function(g) g != null,
+              [
+                // Process each group and drop groups in `config.ignoreGroups`
+                processGroup(group, config)
+                for group in rule.spec.groups
+                if !std.member(config.ignoreGroups, group.name)
+              ]
+            ),
           },
         };
+        if std.length(result.spec.groups) > 0 then
+          result;
 
       {
         process: process,

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_image-registry.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_image-registry.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_ingress-operator.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_ingress-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_insights.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_insights.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver-operator.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-controller-manager-operator.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-controller-manager-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-scheduler-operator.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-scheduler-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-api.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-api.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-config-operator.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-config-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_monitoring.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_monitoring.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_multus.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_multus.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_network-operator.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_network-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_operator-lifecycle-manager.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_operator-lifecycle-manager.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_operators-redhat.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_operators-redhat.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_user-workload-monitoring.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_user-workload-monitoring.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_cloud-credential-operator.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_cloud-credential-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-machine-approver.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-machine-approver.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-node-tuning-operator.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-node-tuning-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-samples-operator.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-samples-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-storage-operator.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-storage-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-version.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-version.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_console-operator.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_console-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_dns-operator.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_dns-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_etcd-operator.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_etcd-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -357,21 +357,26 @@ spec:
               config.ignoreNames,
               std.get(r, 'alert', '')
             )
-          );
+          ) ||
+          // drop all recording rules
+          std.objectHas(r, 'record');
         group {
           rules: std.filter(function(rule) !drop(rule), super.rules),
         };
 
-      local processGroup(group, config) = std.foldl(
-        function(g, func) func(g, config),
-        [
-          procFilterRules,
-          procPatchExprSelector,
-          procPatchExprUserWorkload,
-          procPatchRules,
-        ],
-        group
-      );
+      local processGroup(group, config) =
+        local processed = std.foldl(
+          function(g, func) func(g, config),
+          [
+            procFilterRules,
+            procPatchExprSelector,
+            procPatchExprUserWorkload,
+            procPatchRules,
+          ],
+          group
+        );
+        if std.length(processed.rules) > 0 then
+          processed;
 
       local process(rule, configGlobal, configComponent, enableOwnerRefrences=true) =
         local config = {
@@ -389,7 +394,7 @@ spec:
           renderedExcludeSelector: std.join('|', renderArray(configGlobal.excludeNamespaces + std.get(configComponent, 'excludeNamespaces', []))),
           componentName: std.get(configComponent, 'component', 'openshift4-monitoring'),
         };
-        {
+        local result = {
           apiVersion: 'monitoring.coreos.com/v1',
           kind: 'PrometheusRule',
           metadata: {
@@ -407,14 +412,19 @@ spec:
             namespace: rule.metadata.namespace,
           },
           spec: {
-            groups: [
-              // Process each group and drop groups in `config.ignoreGroups`
-              processGroup(group, config)
-              for group in rule.spec.groups
-              if !std.member(config.ignoreGroups, group.name)
-            ],
+            groups: std.filter(
+              function(g) g != null,
+              [
+                // Process each group and drop groups in `config.ignoreGroups`
+                processGroup(group, config)
+                for group in rule.spec.groups
+                if !std.member(config.ignoreGroups, group.name)
+              ]
+            ),
           },
         };
+        if std.length(result.spec.groups) > 0 then
+          result;
 
       {
         process: process,

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_image-registry.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_image-registry.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_ingress-operator.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_ingress-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_insights.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_insights.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver-operator.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-controller-manager-operator.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-controller-manager-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-scheduler-operator.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-scheduler-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-api.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-api.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-config-operator.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-config-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_monitoring.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_monitoring.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_multus.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_multus.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_network-operator.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_network-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_operator-lifecycle-manager.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_operator-lifecycle-manager.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_operators-redhat.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_operators-redhat.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_user-workload-monitoring.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_user-workload-monitoring.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_cloud-credential-operator.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_cloud-credential-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-machine-approver.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-machine-approver.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-node-tuning-operator.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-node-tuning-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-samples-operator.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-samples-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-storage-operator.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-storage-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-version.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-version.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_console-operator.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_console-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_dns-operator.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_dns-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_etcd-operator.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_etcd-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -369,21 +369,26 @@ spec:
               config.ignoreNames,
               std.get(r, 'alert', '')
             )
-          );
+          ) ||
+          // drop all recording rules
+          std.objectHas(r, 'record');
         group {
           rules: std.filter(function(rule) !drop(rule), super.rules),
         };
 
-      local processGroup(group, config) = std.foldl(
-        function(g, func) func(g, config),
-        [
-          procFilterRules,
-          procPatchExprSelector,
-          procPatchExprUserWorkload,
-          procPatchRules,
-        ],
-        group
-      );
+      local processGroup(group, config) =
+        local processed = std.foldl(
+          function(g, func) func(g, config),
+          [
+            procFilterRules,
+            procPatchExprSelector,
+            procPatchExprUserWorkload,
+            procPatchRules,
+          ],
+          group
+        );
+        if std.length(processed.rules) > 0 then
+          processed;
 
       local process(rule, configGlobal, configComponent, enableOwnerRefrences=true) =
         local config = {
@@ -401,7 +406,7 @@ spec:
           renderedExcludeSelector: std.join('|', renderArray(configGlobal.excludeNamespaces + std.get(configComponent, 'excludeNamespaces', []))),
           componentName: std.get(configComponent, 'component', 'openshift4-monitoring'),
         };
-        {
+        local result = {
           apiVersion: 'monitoring.coreos.com/v1',
           kind: 'PrometheusRule',
           metadata: {
@@ -419,14 +424,19 @@ spec:
             namespace: rule.metadata.namespace,
           },
           spec: {
-            groups: [
-              // Process each group and drop groups in `config.ignoreGroups`
-              processGroup(group, config)
-              for group in rule.spec.groups
-              if !std.member(config.ignoreGroups, group.name)
-            ],
+            groups: std.filter(
+              function(g) g != null,
+              [
+                // Process each group and drop groups in `config.ignoreGroups`
+                processGroup(group, config)
+                for group in rule.spec.groups
+                if !std.member(config.ignoreGroups, group.name)
+              ]
+            ),
           },
         };
+        if std.length(result.spec.groups) > 0 then
+          result;
 
       {
         process: process,

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_image-registry.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_image-registry.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_ingress-operator.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_ingress-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_insights.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_insights.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver-operator.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-controller-manager-operator.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-controller-manager-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-scheduler-operator.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-scheduler-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-api.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-api.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-config-operator.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-config-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_monitoring.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_monitoring.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_multus.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_multus.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_network-operator.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_network-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_operator-lifecycle-manager.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_operator-lifecycle-manager.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_operators-redhat.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_operators-redhat.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_user-workload-monitoring.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_user-workload-monitoring.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_cloud-credential-operator.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_cloud-credential-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-machine-approver.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-machine-approver.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-node-tuning-operator.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-node-tuning-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-samples-operator.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-samples-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-storage-operator.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-storage-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-version.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_cluster-version.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_console-operator.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_console-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_dns-operator.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_dns-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_etcd-operator.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_etcd-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -357,21 +357,26 @@ spec:
               config.ignoreNames,
               std.get(r, 'alert', '')
             )
-          );
+          ) ||
+          // drop all recording rules
+          std.objectHas(r, 'record');
         group {
           rules: std.filter(function(rule) !drop(rule), super.rules),
         };
 
-      local processGroup(group, config) = std.foldl(
-        function(g, func) func(g, config),
-        [
-          procFilterRules,
-          procPatchExprSelector,
-          procPatchExprUserWorkload,
-          procPatchRules,
-        ],
-        group
-      );
+      local processGroup(group, config) =
+        local processed = std.foldl(
+          function(g, func) func(g, config),
+          [
+            procFilterRules,
+            procPatchExprSelector,
+            procPatchExprUserWorkload,
+            procPatchRules,
+          ],
+          group
+        );
+        if std.length(processed.rules) > 0 then
+          processed;
 
       local process(rule, configGlobal, configComponent, enableOwnerRefrences=true) =
         local config = {
@@ -389,7 +394,7 @@ spec:
           renderedExcludeSelector: std.join('|', renderArray(configGlobal.excludeNamespaces + std.get(configComponent, 'excludeNamespaces', []))),
           componentName: std.get(configComponent, 'component', 'openshift4-monitoring'),
         };
-        {
+        local result = {
           apiVersion: 'monitoring.coreos.com/v1',
           kind: 'PrometheusRule',
           metadata: {
@@ -407,14 +412,19 @@ spec:
             namespace: rule.metadata.namespace,
           },
           spec: {
-            groups: [
-              // Process each group and drop groups in `config.ignoreGroups`
-              processGroup(group, config)
-              for group in rule.spec.groups
-              if !std.member(config.ignoreGroups, group.name)
-            ],
+            groups: std.filter(
+              function(g) g != null,
+              [
+                // Process each group and drop groups in `config.ignoreGroups`
+                processGroup(group, config)
+                for group in rule.spec.groups
+                if !std.member(config.ignoreGroups, group.name)
+              ]
+            ),
           },
         };
+        if std.length(result.spec.groups) > 0 then
+          result;
 
       {
         process: process,

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_image-registry.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_image-registry.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_ingress-operator.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_ingress-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_insights.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_insights.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver-operator.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-apiserver.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-controller-manager-operator.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-controller-manager-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-scheduler-operator.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_kube-scheduler-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-api.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-api.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-config-operator.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_machine-config-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_monitoring.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_monitoring.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_multus.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_multus.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_network-operator.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_network-operator.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_operator-lifecycle-manager.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_operator-lifecycle-manager.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_operators-redhat.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_operators-redhat.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_user-workload-monitoring.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_user-workload-monitoring.yaml
@@ -80,16 +80,20 @@ spec:
         local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
         if std.length(cand) > 0 then cand[0];
 
-      if or != null && !inDelete(or) then [
-        renderer.process(or, configGlobal, configComponent)
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
       ]
     )
-    else [
-      // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
-      renderer.process(or, configGlobal, configComponent),
-      for or in opRules
-      if !inDelete(or)
-    ]
   triggers:
     - name: op_rules
       watchContextResource:


### PR DESCRIPTION
There's no point in copying existing recording rules with Espejote, since we don't provide any way to modify them at all. The only thing we get from copying them is that we have additional rule evaluations and higher storage consumption.

Note that we used to drop all upstream recording rules in component version v6.x since we were using the alert-patching library's `filterRules()` (which defaults to `preserveRecordingRules=false`) to filter the downloaded upstream rules.



## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
