### PR TITLE
Include openshift-marketplace alert rules

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -124,6 +124,7 @@ parameters:
       - openshift-kube-scheduler-operator
       - openshift-machine-api
       - openshift-machine-config-operator
+      - openshift-marketplace
       - openshift-multus
       - openshift-network-operator
       - openshift-operator-lifecycle-manager

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -81,6 +81,9 @@ subjects:
     namespace: openshift-machine-config-operator
   - kind: ServiceAccount
     name: openshift4-monitoring-rules
+    namespace: openshift-marketplace
+  - kind: ServiceAccount
+    name: openshift4-monitoring-rules
     namespace: openshift-monitoring
   - kind: ServiceAccount
     name: openshift4-monitoring-rules

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_marketplace.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/40_oprules_marketplace.yaml
@@ -1,0 +1,138 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - '*'
+  - apiGroups:
+      - espejote.io
+    resourceNames:
+      - openshift4-monitoring-rules
+    resources:
+      - jsonnetlibraries
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift4-monitoring-rules
+subjects:
+  - kind: ServiceAccount
+    name: openshift4-monitoring-rules
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  labels:
+    app.kubernetes.io/name: openshift4-monitoring-rules
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+spec:
+  context:
+    - name: op_rules
+      resource:
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        labelSelector:
+          matchExpressions:
+            - key: espejote.io/created-by
+              operator: DoesNotExist
+            - key: espejote.io/ignore
+              operator: DoesNotExist
+  serviceAccountRef:
+    name: openshift4-monitoring-rules
+  template: |
+    local esp = import 'espejote.libsonnet';
+
+    local renderer = import 'lib/openshift4-monitoring-rules/renderer_v1.libsonnet';
+    local configGlobal = import 'lib/openshift4-monitoring-rules/config_v1.json';
+    local configComponent = import 'openshift4-monitoring-rules/config.json';
+
+    local opRules = esp.context().op_rules;
+    local inDelete(obj) = std.get(obj.metadata, 'deletionTimestamp', '') != '';
+
+    if std.member([ 'op_rules', 'generated_rules' ], esp.triggerName()) then (
+      // if the trigger is 'op_rules' or 'generated_rules', render single op_rule
+      local trigger = esp.triggerData();
+      local or = if esp.triggerName() == 'op_rules' then
+        trigger.resource
+      else
+        local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
+        if std.length(cand) > 0 then cand[0];
+
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
+      ]
+    )
+  triggers:
+    - name: op_rules
+      watchContextResource:
+        name: op_rules
+    - name: generated_rules
+      watchResource:
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        labelSelector:
+          matchExpressions:
+            - key: espejote.io/created-by
+              operator: In
+              values:
+                - openshift4-monitoring-rules
+    - name: jslib_global
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: openshift4-monitoring-rules
+        namespace: syn-espejote
+    - name: jslib_component
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: openshift4-monitoring-rules
+        namespace: openshift-marketplace
+---
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  labels:
+    app.kubernetes.io/name: openshift4-monitoring-rules
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+spec:
+  data:
+    config.json: |-
+      {
+          "ignoreNames": [
+              "AlertmanagerConfigInconsistent"
+          ]
+      }

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -81,6 +81,9 @@ subjects:
     namespace: openshift-machine-config-operator
   - kind: ServiceAccount
     name: openshift4-monitoring-rules
+    namespace: openshift-marketplace
+  - kind: ServiceAccount
+    name: openshift4-monitoring-rules
     namespace: openshift-monitoring
   - kind: ServiceAccount
     name: openshift4-monitoring-rules

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_marketplace.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/40_oprules_marketplace.yaml
@@ -1,0 +1,138 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - '*'
+  - apiGroups:
+      - espejote.io
+    resourceNames:
+      - openshift4-monitoring-rules
+    resources:
+      - jsonnetlibraries
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift4-monitoring-rules
+subjects:
+  - kind: ServiceAccount
+    name: openshift4-monitoring-rules
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  labels:
+    app.kubernetes.io/name: openshift4-monitoring-rules
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+spec:
+  context:
+    - name: op_rules
+      resource:
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        labelSelector:
+          matchExpressions:
+            - key: espejote.io/created-by
+              operator: DoesNotExist
+            - key: espejote.io/ignore
+              operator: DoesNotExist
+  serviceAccountRef:
+    name: openshift4-monitoring-rules
+  template: |
+    local esp = import 'espejote.libsonnet';
+
+    local renderer = import 'lib/openshift4-monitoring-rules/renderer_v1.libsonnet';
+    local configGlobal = import 'lib/openshift4-monitoring-rules/config_v1.json';
+    local configComponent = import 'openshift4-monitoring-rules/config.json';
+
+    local opRules = esp.context().op_rules;
+    local inDelete(obj) = std.get(obj.metadata, 'deletionTimestamp', '') != '';
+
+    if std.member([ 'op_rules', 'generated_rules' ], esp.triggerName()) then (
+      // if the trigger is 'op_rules' or 'generated_rules', render single op_rule
+      local trigger = esp.triggerData();
+      local or = if esp.triggerName() == 'op_rules' then
+        trigger.resource
+      else
+        local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
+        if std.length(cand) > 0 then cand[0];
+
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
+      ]
+    )
+  triggers:
+    - name: op_rules
+      watchContextResource:
+        name: op_rules
+    - name: generated_rules
+      watchResource:
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        labelSelector:
+          matchExpressions:
+            - key: espejote.io/created-by
+              operator: In
+              values:
+                - openshift4-monitoring-rules
+    - name: jslib_global
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: openshift4-monitoring-rules
+        namespace: syn-espejote
+    - name: jslib_component
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: openshift4-monitoring-rules
+        namespace: openshift-marketplace
+---
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  labels:
+    app.kubernetes.io/name: openshift4-monitoring-rules
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+spec:
+  data:
+    config.json: |-
+      {
+          "ignoreNames": [
+              "AlertmanagerConfigInconsistent"
+          ]
+      }

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -81,6 +81,9 @@ subjects:
     namespace: openshift-machine-config-operator
   - kind: ServiceAccount
     name: openshift4-monitoring-rules
+    namespace: openshift-marketplace
+  - kind: ServiceAccount
+    name: openshift4-monitoring-rules
     namespace: openshift-monitoring
   - kind: ServiceAccount
     name: openshift4-monitoring-rules

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_marketplace.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/40_oprules_marketplace.yaml
@@ -1,0 +1,138 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - '*'
+  - apiGroups:
+      - espejote.io
+    resourceNames:
+      - openshift4-monitoring-rules
+    resources:
+      - jsonnetlibraries
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift4-monitoring-rules
+subjects:
+  - kind: ServiceAccount
+    name: openshift4-monitoring-rules
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  labels:
+    app.kubernetes.io/name: openshift4-monitoring-rules
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+spec:
+  context:
+    - name: op_rules
+      resource:
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        labelSelector:
+          matchExpressions:
+            - key: espejote.io/created-by
+              operator: DoesNotExist
+            - key: espejote.io/ignore
+              operator: DoesNotExist
+  serviceAccountRef:
+    name: openshift4-monitoring-rules
+  template: |
+    local esp = import 'espejote.libsonnet';
+
+    local renderer = import 'lib/openshift4-monitoring-rules/renderer_v1.libsonnet';
+    local configGlobal = import 'lib/openshift4-monitoring-rules/config_v1.json';
+    local configComponent = import 'openshift4-monitoring-rules/config.json';
+
+    local opRules = esp.context().op_rules;
+    local inDelete(obj) = std.get(obj.metadata, 'deletionTimestamp', '') != '';
+
+    if std.member([ 'op_rules', 'generated_rules' ], esp.triggerName()) then (
+      // if the trigger is 'op_rules' or 'generated_rules', render single op_rule
+      local trigger = esp.triggerData();
+      local or = if esp.triggerName() == 'op_rules' then
+        trigger.resource
+      else
+        local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
+        if std.length(cand) > 0 then cand[0];
+
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
+      ]
+    )
+  triggers:
+    - name: op_rules
+      watchContextResource:
+        name: op_rules
+    - name: generated_rules
+      watchResource:
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        labelSelector:
+          matchExpressions:
+            - key: espejote.io/created-by
+              operator: In
+              values:
+                - openshift4-monitoring-rules
+    - name: jslib_global
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: openshift4-monitoring-rules
+        namespace: syn-espejote
+    - name: jslib_component
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: openshift4-monitoring-rules
+        namespace: openshift-marketplace
+---
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  labels:
+    app.kubernetes.io/name: openshift4-monitoring-rules
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+spec:
+  data:
+    config.json: |-
+      {
+          "ignoreNames": [
+              "AlertmanagerConfigInconsistent"
+          ]
+      }

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -81,6 +81,9 @@ subjects:
     namespace: openshift-machine-config-operator
   - kind: ServiceAccount
     name: openshift4-monitoring-rules
+    namespace: openshift-marketplace
+  - kind: ServiceAccount
+    name: openshift4-monitoring-rules
     namespace: openshift-monitoring
   - kind: ServiceAccount
     name: openshift4-monitoring-rules

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_marketplace.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/40_oprules_marketplace.yaml
@@ -1,0 +1,138 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - '*'
+  - apiGroups:
+      - espejote.io
+    resourceNames:
+      - openshift4-monitoring-rules
+    resources:
+      - jsonnetlibraries
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift4-monitoring-rules
+subjects:
+  - kind: ServiceAccount
+    name: openshift4-monitoring-rules
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  labels:
+    app.kubernetes.io/name: openshift4-monitoring-rules
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+spec:
+  context:
+    - name: op_rules
+      resource:
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        labelSelector:
+          matchExpressions:
+            - key: espejote.io/created-by
+              operator: DoesNotExist
+            - key: espejote.io/ignore
+              operator: DoesNotExist
+  serviceAccountRef:
+    name: openshift4-monitoring-rules
+  template: |
+    local esp = import 'espejote.libsonnet';
+
+    local renderer = import 'lib/openshift4-monitoring-rules/renderer_v1.libsonnet';
+    local configGlobal = import 'lib/openshift4-monitoring-rules/config_v1.json';
+    local configComponent = import 'openshift4-monitoring-rules/config.json';
+
+    local opRules = esp.context().op_rules;
+    local inDelete(obj) = std.get(obj.metadata, 'deletionTimestamp', '') != '';
+
+    if std.member([ 'op_rules', 'generated_rules' ], esp.triggerName()) then (
+      // if the trigger is 'op_rules' or 'generated_rules', render single op_rule
+      local trigger = esp.triggerData();
+      local or = if esp.triggerName() == 'op_rules' then
+        trigger.resource
+      else
+        local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
+        if std.length(cand) > 0 then cand[0];
+
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
+      ]
+    )
+  triggers:
+    - name: op_rules
+      watchContextResource:
+        name: op_rules
+    - name: generated_rules
+      watchResource:
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        labelSelector:
+          matchExpressions:
+            - key: espejote.io/created-by
+              operator: In
+              values:
+                - openshift4-monitoring-rules
+    - name: jslib_global
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: openshift4-monitoring-rules
+        namespace: syn-espejote
+    - name: jslib_component
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: openshift4-monitoring-rules
+        namespace: openshift-marketplace
+---
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  labels:
+    app.kubernetes.io/name: openshift4-monitoring-rules
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+spec:
+  data:
+    config.json: |-
+      {
+          "ignoreNames": [
+              "AlertmanagerConfigInconsistent"
+          ]
+      }

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -81,6 +81,9 @@ subjects:
     namespace: openshift-machine-config-operator
   - kind: ServiceAccount
     name: openshift4-monitoring-rules
+    namespace: openshift-marketplace
+  - kind: ServiceAccount
+    name: openshift4-monitoring-rules
     namespace: openshift-monitoring
   - kind: ServiceAccount
     name: openshift4-monitoring-rules

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_marketplace.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/40_oprules_marketplace.yaml
@@ -1,0 +1,138 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - '*'
+  - apiGroups:
+      - espejote.io
+    resourceNames:
+      - openshift4-monitoring-rules
+    resources:
+      - jsonnetlibraries
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift4-monitoring-rules
+subjects:
+  - kind: ServiceAccount
+    name: openshift4-monitoring-rules
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  labels:
+    app.kubernetes.io/name: openshift4-monitoring-rules
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+spec:
+  context:
+    - name: op_rules
+      resource:
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        labelSelector:
+          matchExpressions:
+            - key: espejote.io/created-by
+              operator: DoesNotExist
+            - key: espejote.io/ignore
+              operator: DoesNotExist
+  serviceAccountRef:
+    name: openshift4-monitoring-rules
+  template: |
+    local esp = import 'espejote.libsonnet';
+
+    local renderer = import 'lib/openshift4-monitoring-rules/renderer_v1.libsonnet';
+    local configGlobal = import 'lib/openshift4-monitoring-rules/config_v1.json';
+    local configComponent = import 'openshift4-monitoring-rules/config.json';
+
+    local opRules = esp.context().op_rules;
+    local inDelete(obj) = std.get(obj.metadata, 'deletionTimestamp', '') != '';
+
+    if std.member([ 'op_rules', 'generated_rules' ], esp.triggerName()) then (
+      // if the trigger is 'op_rules' or 'generated_rules', render single op_rule
+      local trigger = esp.triggerData();
+      local or = if esp.triggerName() == 'op_rules' then
+        trigger.resource
+      else
+        local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
+        if std.length(cand) > 0 then cand[0];
+
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
+      ]
+    )
+  triggers:
+    - name: op_rules
+      watchContextResource:
+        name: op_rules
+    - name: generated_rules
+      watchResource:
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        labelSelector:
+          matchExpressions:
+            - key: espejote.io/created-by
+              operator: In
+              values:
+                - openshift4-monitoring-rules
+    - name: jslib_global
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: openshift4-monitoring-rules
+        namespace: syn-espejote
+    - name: jslib_component
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: openshift4-monitoring-rules
+        namespace: openshift-marketplace
+---
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  labels:
+    app.kubernetes.io/name: openshift4-monitoring-rules
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+spec:
+  data:
+    config.json: |-
+      {
+          "ignoreNames": [
+              "AlertmanagerConfigInconsistent"
+          ]
+      }

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -81,6 +81,9 @@ subjects:
     namespace: openshift-machine-config-operator
   - kind: ServiceAccount
     name: openshift4-monitoring-rules
+    namespace: openshift-marketplace
+  - kind: ServiceAccount
+    name: openshift4-monitoring-rules
     namespace: openshift-monitoring
   - kind: ServiceAccount
     name: openshift4-monitoring-rules

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_marketplace.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/40_oprules_marketplace.yaml
@@ -1,0 +1,138 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - '*'
+  - apiGroups:
+      - espejote.io
+    resourceNames:
+      - openshift4-monitoring-rules
+    resources:
+      - jsonnetlibraries
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift4-monitoring-rules
+subjects:
+  - kind: ServiceAccount
+    name: openshift4-monitoring-rules
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  labels:
+    app.kubernetes.io/name: openshift4-monitoring-rules
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+spec:
+  context:
+    - name: op_rules
+      resource:
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        labelSelector:
+          matchExpressions:
+            - key: espejote.io/created-by
+              operator: DoesNotExist
+            - key: espejote.io/ignore
+              operator: DoesNotExist
+  serviceAccountRef:
+    name: openshift4-monitoring-rules
+  template: |
+    local esp = import 'espejote.libsonnet';
+
+    local renderer = import 'lib/openshift4-monitoring-rules/renderer_v1.libsonnet';
+    local configGlobal = import 'lib/openshift4-monitoring-rules/config_v1.json';
+    local configComponent = import 'openshift4-monitoring-rules/config.json';
+
+    local opRules = esp.context().op_rules;
+    local inDelete(obj) = std.get(obj.metadata, 'deletionTimestamp', '') != '';
+
+    if std.member([ 'op_rules', 'generated_rules' ], esp.triggerName()) then (
+      // if the trigger is 'op_rules' or 'generated_rules', render single op_rule
+      local trigger = esp.triggerData();
+      local or = if esp.triggerName() == 'op_rules' then
+        trigger.resource
+      else
+        local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
+        if std.length(cand) > 0 then cand[0];
+
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
+      ]
+    )
+  triggers:
+    - name: op_rules
+      watchContextResource:
+        name: op_rules
+    - name: generated_rules
+      watchResource:
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        labelSelector:
+          matchExpressions:
+            - key: espejote.io/created-by
+              operator: In
+              values:
+                - openshift4-monitoring-rules
+    - name: jslib_global
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: openshift4-monitoring-rules
+        namespace: syn-espejote
+    - name: jslib_component
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: openshift4-monitoring-rules
+        namespace: openshift-marketplace
+---
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  labels:
+    app.kubernetes.io/name: openshift4-monitoring-rules
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+spec:
+  data:
+    config.json: |-
+      {
+          "ignoreNames": [
+              "AlertmanagerConfigInconsistent"
+          ]
+      }

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_global.yaml
@@ -81,6 +81,9 @@ subjects:
     namespace: openshift-machine-config-operator
   - kind: ServiceAccount
     name: openshift4-monitoring-rules
+    namespace: openshift-marketplace
+  - kind: ServiceAccount
+    name: openshift4-monitoring-rules
     namespace: openshift-monitoring
   - kind: ServiceAccount
     name: openshift4-monitoring-rules

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_marketplace.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/40_oprules_marketplace.yaml
@@ -1,0 +1,138 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - '*'
+  - apiGroups:
+      - espejote.io
+    resourceNames:
+      - openshift4-monitoring-rules
+    resources:
+      - jsonnetlibraries
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift4-monitoring-rules
+subjects:
+  - kind: ServiceAccount
+    name: openshift4-monitoring-rules
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  labels:
+    app.kubernetes.io/name: openshift4-monitoring-rules
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+spec:
+  context:
+    - name: op_rules
+      resource:
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        labelSelector:
+          matchExpressions:
+            - key: espejote.io/created-by
+              operator: DoesNotExist
+            - key: espejote.io/ignore
+              operator: DoesNotExist
+  serviceAccountRef:
+    name: openshift4-monitoring-rules
+  template: |
+    local esp = import 'espejote.libsonnet';
+
+    local renderer = import 'lib/openshift4-monitoring-rules/renderer_v1.libsonnet';
+    local configGlobal = import 'lib/openshift4-monitoring-rules/config_v1.json';
+    local configComponent = import 'openshift4-monitoring-rules/config.json';
+
+    local opRules = esp.context().op_rules;
+    local inDelete(obj) = std.get(obj.metadata, 'deletionTimestamp', '') != '';
+
+    if std.member([ 'op_rules', 'generated_rules' ], esp.triggerName()) then (
+      // if the trigger is 'op_rules' or 'generated_rules', render single op_rule
+      local trigger = esp.triggerData();
+      local or = if esp.triggerName() == 'op_rules' then
+        trigger.resource
+      else
+        local cand = std.filter(function(r) r.metadata.name == trigger.resource.metadata.ownerReferences[0].name, opRules);
+        if std.length(cand) > 0 then cand[0];
+
+      if or != null && !inDelete(or) then
+        local proc = renderer.process(or, configGlobal, configComponent);
+        if proc != null then
+          proc
+    )
+    else std.filter(
+      function(r) r != null,
+      [
+        // if the trigger is not 'op_rules' or 'generated_rules', render all op_rules
+        renderer.process(or, configGlobal, configComponent),
+        for or in opRules
+        if !inDelete(or)
+      ]
+    )
+  triggers:
+    - name: op_rules
+      watchContextResource:
+        name: op_rules
+    - name: generated_rules
+      watchResource:
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        labelSelector:
+          matchExpressions:
+            - key: espejote.io/created-by
+              operator: In
+              values:
+                - openshift4-monitoring-rules
+    - name: jslib_global
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: openshift4-monitoring-rules
+        namespace: syn-espejote
+    - name: jslib_component
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: openshift4-monitoring-rules
+        namespace: openshift-marketplace
+---
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  labels:
+    app.kubernetes.io/name: openshift4-monitoring-rules
+  name: openshift4-monitoring-rules
+  namespace: openshift-marketplace
+spec:
+  data:
+    config.json: |-
+      {
+          "ignoreNames": [
+              "AlertmanagerConfigInconsistent"
+          ]
+      }


### PR DESCRIPTION
For completeness we should include the `openshift-marketplace` namespace. It's the only openshift-* namespace with prometheus rules that is currently not included. If the alert(s) itself turn out to be useless we should exclude the individual alerts. Like this we ensure we don't "miss out" on any future useful alerts

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
