### PR TITLE
Gracefully skip broken component instance parameters in alert routing namespace discovery

### DIFF
--- a/component/alert-routing-discovery.libsonnet
+++ b/component/alert-routing-discovery.libsonnet
@@ -20,7 +20,9 @@ local discoverNS = function(app)
   local f = function(k)
     if std.objectHas(params, k) then
       local p = params[k];
-      if std.objectHas(p, 'namespace') then
+      if !std.isObject(p) then
+        std.trace('[WARN] parameters for component instance "%s" not an object!' % k, null)
+      else if std.isObject(p) && std.objectHas(p, 'namespace') then
         if std.isString(p.namespace) then
           p.namespace
         else if std.isObject(p.namespace) && std.objectHas(p.namespace, 'name') && std.isString(p.namespace.name) then


### PR DESCRIPTION
This ensures that we don't hard crash when a component instance parameter in the inventory isn't an object (note that this is a bug in general, but the Commodore inventory linting doesn't guard against this yet).


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
