### PR TITLE
Update silences in place instead of expiry and re-creation

### DIFF
--- a/component/scripts/silence.sh
+++ b/component/scripts/silence.sh
@@ -14,9 +14,12 @@ while IFS= read -r silence; do
       '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
   )
 
-  id=$(curl "${curl_opts[@]}" | jq -r ".[] | select(.status.state == \"active\") | select(.comment == \"${comment}\") | .id" | head -n 1)
-  if [ -n "${id}" ]; then
-    body=$(printf %s "${body}" | jq --arg id "${id}" '.id = $id')
+  read id startsAt <<< "$(curl "${curl_opts[@]}" \
+    | jq -r --arg comment "$comment" \
+        '.[] | select(.status.state == "active") | select(.comment == $comment) | .id + " " + .startsAt' \
+    | head -n 1)"
+  if [ -n "${id}" ] && [ -n "${startsAt}" ]; then
+      body=$(printf %s "${body}" | jq --arg id "${id}" --arg startsAt "${startsAt}" '.id = $id | .startsAt |= $startsAt')
   fi
 
   curl "${curl_opts[@]}" -XPOST -d "${body}"

--- a/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/capacity-alerts-with-node-labels/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -17,9 +17,12 @@ data:
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )
 
-      id=$(curl "${curl_opts[@]}" | jq -r ".[] | select(.status.state == \"active\") | select(.comment == \"${comment}\") | .id" | head -n 1)
-      if [ -n "${id}" ]; then
-        body=$(printf %s "${body}" | jq --arg id "${id}" '.id = $id')
+      read id startsAt <<< "$(curl "${curl_opts[@]}" \
+        | jq -r --arg comment "$comment" \
+            '.[] | select(.status.state == "active") | select(.comment == $comment) | .id + " " + .startsAt' \
+        | head -n 1)"
+      if [ -n "${id}" ] && [ -n "${startsAt}" ]; then
+          body=$(printf %s "${body}" | jq --arg id "${id}" --arg startsAt "${startsAt}" '.id = $id | .startsAt |= $startsAt')
       fi
 
       curl "${curl_opts[@]}" -XPOST -d "${body}"
@@ -108,8 +111,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    name: silence-02b30e88
-  name: silence-02b30e88
+    name: silence-16a68df8
+  name: silence-16a68df8
   namespace: openshift-monitoring
 spec:
   completions: 1
@@ -117,7 +120,7 @@ spec:
   template:
     metadata:
       labels:
-        name: silence-02b30e88
+        name: silence-16a68df8
     spec:
       containers:
         - args: []

--- a/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/custom-rules/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -17,9 +17,12 @@ data:
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )
 
-      id=$(curl "${curl_opts[@]}" | jq -r ".[] | select(.status.state == \"active\") | select(.comment == \"${comment}\") | .id" | head -n 1)
-      if [ -n "${id}" ]; then
-        body=$(printf %s "${body}" | jq --arg id "${id}" '.id = $id')
+      read id startsAt <<< "$(curl "${curl_opts[@]}" \
+        | jq -r --arg comment "$comment" \
+            '.[] | select(.status.state == "active") | select(.comment == $comment) | .id + " " + .startsAt' \
+        | head -n 1)"
+      if [ -n "${id}" ] && [ -n "${startsAt}" ]; then
+          body=$(printf %s "${body}" | jq --arg id "${id}" --arg startsAt "${startsAt}" '.id = $id | .startsAt |= $startsAt')
       fi
 
       curl "${curl_opts[@]}" -XPOST -d "${body}"
@@ -108,8 +111,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    name: silence-02b30e88
-  name: silence-02b30e88
+    name: silence-16a68df8
+  name: silence-16a68df8
   namespace: openshift-monitoring
 spec:
   completions: 1
@@ -117,7 +120,7 @@ spec:
   template:
     metadata:
       labels:
-        name: silence-02b30e88
+        name: silence-16a68df8
     spec:
       containers:
         - args: []

--- a/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/defaults/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -17,9 +17,12 @@ data:
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )
 
-      id=$(curl "${curl_opts[@]}" | jq -r ".[] | select(.status.state == \"active\") | select(.comment == \"${comment}\") | .id" | head -n 1)
-      if [ -n "${id}" ]; then
-        body=$(printf %s "${body}" | jq --arg id "${id}" '.id = $id')
+      read id startsAt <<< "$(curl "${curl_opts[@]}" \
+        | jq -r --arg comment "$comment" \
+            '.[] | select(.status.state == "active") | select(.comment == $comment) | .id + " " + .startsAt' \
+        | head -n 1)"
+      if [ -n "${id}" ] && [ -n "${startsAt}" ]; then
+          body=$(printf %s "${body}" | jq --arg id "${id}" --arg startsAt "${startsAt}" '.id = $id | .startsAt |= $startsAt')
       fi
 
       curl "${curl_opts[@]}" -XPOST -d "${body}"
@@ -108,8 +111,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    name: silence-02b30e88
-  name: silence-02b30e88
+    name: silence-16a68df8
+  name: silence-16a68df8
   namespace: openshift-monitoring
 spec:
   completions: 1
@@ -117,7 +120,7 @@ spec:
   template:
     metadata:
       labels:
-        name: silence-02b30e88
+        name: silence-16a68df8
     spec:
       containers:
         - args: []

--- a/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/remote-write/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -17,9 +17,12 @@ data:
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )
 
-      id=$(curl "${curl_opts[@]}" | jq -r ".[] | select(.status.state == \"active\") | select(.comment == \"${comment}\") | .id" | head -n 1)
-      if [ -n "${id}" ]; then
-        body=$(printf %s "${body}" | jq --arg id "${id}" '.id = $id')
+      read id startsAt <<< "$(curl "${curl_opts[@]}" \
+        | jq -r --arg comment "$comment" \
+            '.[] | select(.status.state == "active") | select(.comment == $comment) | .id + " " + .startsAt' \
+        | head -n 1)"
+      if [ -n "${id}" ] && [ -n "${startsAt}" ]; then
+          body=$(printf %s "${body}" | jq --arg id "${id}" --arg startsAt "${startsAt}" '.id = $id | .startsAt |= $startsAt')
       fi
 
       curl "${curl_opts[@]}" -XPOST -d "${body}"
@@ -108,8 +111,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    name: silence-02b30e88
-  name: silence-02b30e88
+    name: silence-16a68df8
+  name: silence-16a68df8
   namespace: openshift-monitoring
 spec:
   completions: 1
@@ -117,7 +120,7 @@ spec:
   template:
     metadata:
       labels:
-        name: silence-02b30e88
+        name: silence-16a68df8
     spec:
       containers:
         - args: []

--- a/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/team-routing/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -17,9 +17,12 @@ data:
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )
 
-      id=$(curl "${curl_opts[@]}" | jq -r ".[] | select(.status.state == \"active\") | select(.comment == \"${comment}\") | .id" | head -n 1)
-      if [ -n "${id}" ]; then
-        body=$(printf %s "${body}" | jq --arg id "${id}" '.id = $id')
+      read id startsAt <<< "$(curl "${curl_opts[@]}" \
+        | jq -r --arg comment "$comment" \
+            '.[] | select(.status.state == "active") | select(.comment == $comment) | .id + " " + .startsAt' \
+        | head -n 1)"
+      if [ -n "${id}" ] && [ -n "${startsAt}" ]; then
+          body=$(printf %s "${body}" | jq --arg id "${id}" --arg startsAt "${startsAt}" '.id = $id | .startsAt |= $startsAt')
       fi
 
       curl "${curl_opts[@]}" -XPOST -d "${body}"
@@ -108,8 +111,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    name: silence-02b30e88
-  name: silence-02b30e88
+    name: silence-16a68df8
+  name: silence-16a68df8
   namespace: openshift-monitoring
 spec:
   completions: 1
@@ -117,7 +120,7 @@ spec:
   template:
     metadata:
       labels:
-        name: silence-02b30e88
+        name: silence-16a68df8
     spec:
       containers:
         - args: []

--- a/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/user-workload-monitoring/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -17,9 +17,12 @@ data:
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )
 
-      id=$(curl "${curl_opts[@]}" | jq -r ".[] | select(.status.state == \"active\") | select(.comment == \"${comment}\") | .id" | head -n 1)
-      if [ -n "${id}" ]; then
-        body=$(printf %s "${body}" | jq --arg id "${id}" '.id = $id')
+      read id startsAt <<< "$(curl "${curl_opts[@]}" \
+        | jq -r --arg comment "$comment" \
+            '.[] | select(.status.state == "active") | select(.comment == $comment) | .id + " " + .startsAt' \
+        | head -n 1)"
+      if [ -n "${id}" ] && [ -n "${startsAt}" ]; then
+          body=$(printf %s "${body}" | jq --arg id "${id}" --arg startsAt "${startsAt}" '.id = $id | .startsAt |= $startsAt')
       fi
 
       curl "${curl_opts[@]}" -XPOST -d "${body}"
@@ -108,8 +111,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    name: silence-02b30e88
-  name: silence-02b30e88
+    name: silence-16a68df8
+  name: silence-16a68df8
   namespace: openshift-monitoring
 spec:
   completions: 1
@@ -117,7 +120,7 @@ spec:
   template:
     metadata:
       labels:
-        name: silence-02b30e88
+        name: silence-16a68df8
     spec:
       containers:
         - args: []

--- a/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/silence.yaml
+++ b/tests/golden/vsphere/openshift4-monitoring/openshift4-monitoring/silence.yaml
@@ -17,9 +17,12 @@ data:
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy'
       )
 
-      id=$(curl "${curl_opts[@]}" | jq -r ".[] | select(.status.state == \"active\") | select(.comment == \"${comment}\") | .id" | head -n 1)
-      if [ -n "${id}" ]; then
-        body=$(printf %s "${body}" | jq --arg id "${id}" '.id = $id')
+      read id startsAt <<< "$(curl "${curl_opts[@]}" \
+        | jq -r --arg comment "$comment" \
+            '.[] | select(.status.state == "active") | select(.comment == $comment) | .id + " " + .startsAt' \
+        | head -n 1)"
+      if [ -n "${id}" ] && [ -n "${startsAt}" ]; then
+          body=$(printf %s "${body}" | jq --arg id "${id}" --arg startsAt "${startsAt}" '.id = $id | .startsAt |= $startsAt')
       fi
 
       curl "${curl_opts[@]}" -XPOST -d "${body}"
@@ -108,8 +111,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    name: silence-02b30e88
-  name: silence-02b30e88
+    name: silence-16a68df8
+  name: silence-16a68df8
   namespace: openshift-monitoring
 spec:
   completions: 1
@@ -117,7 +120,7 @@ spec:
   template:
     metadata:
       labels:
-        name: silence-02b30e88
+        name: silence-16a68df8
     spec:
       containers:
         - args: []


### PR DESCRIPTION
Alertmanager checks if an update modifies the history, in which case it refuses to update the silence. Instead it will expire it and create a new one. By keeping the orignial start time we don't modify the history.

Sometimes alerts slip through in the short window between expiry and re-creation.

cf. https://github.com/prometheus/alertmanager/blob/7e54eebd16028a66263077ff4cee297b51882996/silence/silence.go#L944

Real fix for https://github.com/appuio/component-openshift4-monitoring/pull/169 from 2023 :grin: 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
